### PR TITLE
hotfix: correct Office 365 messaging and darwin-rebuild sudo requirements (Hotfix #8)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4130,12 +4130,10 @@ display_next_steps() {
     echo ""
     echo "  2. Activate licensed applications (see list below)"
     echo ""
-    echo "  3. Install Office 365 manually (not available via Nix/Homebrew)"
-    echo ""
 
     # Ollama verification step only for Power profile
     if [[ "${INSTALL_PROFILE:-standard}" == "power" ]]; then
-        echo "  4. Verify Ollama models (Power profile):"
+        echo "  3. Verify Ollama models (Power profile):"
         echo "     ollama list"
         echo "     Expected: gpt-oss:20b, qwen2.5-coder:32b, llama3.1:70b, deepseek-r1:32b"
         echo ""
@@ -4169,12 +4167,12 @@ display_useful_commands() {
 display_manual_activation_apps() {
     echo "Apps Requiring Manual Activation:"
     echo ""
-    echo "  • 1Password"
-    echo "  • Office 365 (manual installation required)"
+    echo "  • 1Password (license key required)"
+    echo "  • Microsoft Office (Office 365 subscription required)"
 
     # Parallels Desktop only for Power profile
     if [[ "${INSTALL_PROFILE:-standard}" == "power" ]]; then
-        echo "  • Parallels Desktop"
+        echo "  • Parallels Desktop (license key required)"
     fi
 
     echo ""

--- a/docs/testing-installation-summary.md
+++ b/docs/testing-installation-summary.md
@@ -244,7 +244,7 @@ Power Profile Summary:
 
 **Expected Results**:
 - ✅ Nix version displayed and accurate (run `nix --version`)
-- ✅ nix-darwin confirmed (run `darwin-rebuild --version`)
+- ✅ nix-darwin confirmed (run `sudo darwin-rebuild --version`)
 - ✅ Home Manager confirmed (run `home-manager --version`)
 - ✅ Profile name matches user selection
 - ✅ App count reasonable (47-51 range)
@@ -254,8 +254,8 @@ Power Profile Summary:
 # Verify Nix
 nix --version
 
-# Verify nix-darwin
-darwin-rebuild --version
+# Verify nix-darwin (requires sudo)
+sudo darwin-rebuild --version
 
 # Verify Home Manager (if available)
 home-manager --version || echo "Home Manager not in PATH yet"

--- a/setup.sh
+++ b/setup.sh
@@ -334,8 +334,8 @@ main() {
     echo ""
     log_info "Next steps:"
     echo "  1. Restart your terminal to load new shell configuration"
-    echo "  2. Verify installation: nix --version && darwin-rebuild --version"
-    echo "  3. Check system configuration: darwin-rebuild check"
+    echo "  2. Verify installation: nix --version && sudo darwin-rebuild --version"
+    echo "  3. Check system configuration: sudo darwin-rebuild check"
     echo ""
 }
 

--- a/tests/09-installation-summary.bats
+++ b/tests/09-installation-summary.bats
@@ -210,10 +210,14 @@ setup() {
     assert_output --regexp "(Activate|licensed|license)"
 }
 
-@test "display_next_steps: mentions Office 365 installation" {
+@test "display_next_steps: shows 2 steps for Standard profile" {
+    export INSTALL_PROFILE="standard"
+
     run display_next_steps
     assert_success
-    assert_output --regexp "(Office 365|Office|Microsoft)"
+    assert_output --regexp "1\."
+    assert_output --regexp "2\."
+    refute_output --regexp "3\."
 }
 
 @test "display_next_steps: includes Ollama verification for Power profile" {
@@ -347,10 +351,10 @@ setup() {
     assert_output --partial "1Password"
 }
 
-@test "display_manual_activation_apps: lists Office 365" {
+@test "display_manual_activation_apps: lists Microsoft Office" {
     run display_manual_activation_apps
     assert_success
-    assert_output --partial "Office 365"
+    assert_output --regexp "(Microsoft Office|Office 365)"
 }
 
 @test "display_manual_activation_apps: includes Parallels for Power profile" {


### PR DESCRIPTION
## Hotfix Summary
Fixes two issues identified by FX after Story 01.8-001 merge:

### Issue 1: Office 365 Messaging Incorrect
**Problem**: Phase 9 summary incorrectly states Office 365 requires manual installation
**Reality**: Office 365 (microsoft-office cask) IS installed automatically via Homebrew during nix-darwin build

**Changes**:
- ✅ **Removed** step 3 "Install Office 365 manually (not available via Nix/Homebrew)" from next steps
- ✅ **Updated** manual activation list text:
  - OLD: "Office 365 (manual installation required)"
  - NEW: "Microsoft Office (Office 365 subscription required)"
- ✅ **Renumbered** steps: Standard profile now shows 2 steps (was 3), Power profile shows 3 steps with Ollama (was 4)
- ✅ **Clarified** distinction: App is installed automatically, only license activation is manual

### Issue 2: darwin-rebuild Commands Missing sudo
**Problem**: Documentation references `darwin-rebuild --version` and `darwin-rebuild check` without sudo
**Reality**: ALL darwin-rebuild commands require sudo on macOS

**Changes**:
- ✅ **Updated** setup.sh next steps to use `sudo darwin-rebuild`
- ✅ **Updated** docs/testing-installation-summary.md verification commands to use `sudo darwin-rebuild`
- ✅ **Note**: bootstrap.sh already correctly uses `sudo darwin-rebuild switch` (no change needed)

## Files Changed
- `bootstrap.sh`: Updated display_next_steps() and display_manual_activation_apps()
- `tests/09-installation-summary.bats`: Updated tests to match corrected behavior
- `setup.sh`: Added sudo to darwin-rebuild commands
- `docs/testing-installation-summary.md`: Added sudo to verification commands

## Testing
- ✅ All 54 BATS tests PASSING
- ✅ Shellcheck validation: CLEAN
- ✅ Manual review: Messaging now accurate

## Impact
**User Impact**: LOW - Clarifies messaging, no functional changes
**Risk**: VERY LOW - Only text changes, all tests pass

## Identified By
FX - Thank you for catching these issues!

Fixes: #hotfix-8