### PR TITLE
hotfix: clarify sudo requirement for rebuild/update commands (Hotfix #9)

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4150,10 +4150,12 @@ display_next_steps() {
 display_useful_commands() {
     echo "Useful Commands:"
     echo ""
-    echo "  rebuild       Apply configuration changes from ${REPO_CLONE_DIR}"
-    echo "  update        Update packages and rebuild system"
-    echo "  health-check  Verify system health and configuration"
-    echo "  cleanup       Run garbage collection and free disk space"
+    echo "  sudo rebuild       Apply configuration changes from ${REPO_CLONE_DIR}"
+    echo "  sudo update        Update packages and rebuild system"
+    echo "  health-check       Verify system health and configuration"
+    echo "  cleanup            Run garbage collection and free disk space"
+    echo ""
+    echo "  Note: rebuild and update require sudo (they use darwin-rebuild)"
     echo ""
 
     return 0

--- a/tests/09-installation-summary.bats
+++ b/tests/09-installation-summary.bats
@@ -255,7 +255,7 @@ setup() {
 }
 
 #############################################################################
-# COMMAND REFERENCE TESTS (8 tests)
+# COMMAND REFERENCE TESTS (9 tests)
 #############################################################################
 
 @test "display_useful_commands: shows rebuild command" {
@@ -308,6 +308,15 @@ setup() {
     assert_success
     # Should mention where config comes from
     assert_output --regexp "(Documents/nix-install|configuration)"
+}
+
+@test "display_useful_commands: mentions sudo requirement for darwin-rebuild commands" {
+    run display_useful_commands
+    assert_success
+    # Should mention that rebuild and update require sudo
+    assert_output --partial "sudo rebuild"
+    assert_output --partial "sudo update"
+    assert_output --regexp "(Note|note).*sudo.*darwin-rebuild"
 }
 
 #############################################################################


### PR DESCRIPTION
## Hotfix Summary
Fixes confusing command reference in Phase 9 installation summary.

### Problem
The "Useful Commands" section displayed:
```
Useful Commands:

  rebuild       Apply configuration changes from ~/Documents/nix-install
  update        Update packages and rebuild system
  health-check  Verify system health and configuration
  cleanup       Run garbage collection and free disk space
```

This was **confusing** because:
- `rebuild` and `update` internally call `darwin-rebuild`
- `darwin-rebuild` requires sudo
- Users would try `rebuild` and get permission errors
- No indication that sudo was needed

### Solution
Updated `display_useful_commands()` to explicitly show sudo requirement:

```
Useful Commands:

  sudo rebuild       Apply configuration changes from ~/Documents/nix-install
  sudo update        Update packages and rebuild system
  health-check       Verify system health and configuration
  cleanup            Run garbage collection and free disk space

  Note: rebuild and update require sudo (they use darwin-rebuild)
```

**Changes**:
- ✅ Added `sudo` prefix to rebuild and update commands
- ✅ Added explanatory note about sudo requirement
- ✅ health-check and cleanup remain without sudo (don't need it)

### Files Changed
1. **bootstrap.sh**: Updated `display_useful_commands()` function (+3 lines)
   - Line 4153-4154: Added sudo to rebuild and update
   - Line 4158-4159: Added explanatory note
2. **tests/09-installation-summary.bats**: Added sudo requirement test (+9 lines)
   - New test validates sudo is shown for rebuild/update
   - New test validates explanatory note is present
   - Updated test count: 54 → 55 tests

### Testing
- ✅ All 55 BATS tests PASSING (was 54, added 1 new test)
- ✅ Shellcheck validation: CLEAN (0 errors, 0 warnings)
- ✅ Bash syntax check: PASSED

### Impact
- **Fixes**: User confusion about command requirements
- **Prevents**: Permission denied errors when users try `rebuild`
- **Improves**: Command reference clarity and accuracy
- **User Experience**: Clear expectations about sudo prompts

### Identified By
FX - "darwin-rebuild requires sudo. Update the summary accordingly it is confusing"

### Example Output (After Fix)

**Standard Profile**:
```
════════════════════════════════════════════════════════════════════
Useful Commands:

  sudo rebuild       Apply configuration changes from /Users/fx/Documents/nix-install
  sudo update        Update packages and rebuild system
  health-check       Verify system health and configuration
  cleanup            Run garbage collection and free disk space

  Note: rebuild and update require sudo (they use darwin-rebuild)

════════════════════════════════════════════════════════════════════
```

Now users will know upfront that they need to use `sudo rebuild` instead of discovering it through permission errors.

### Risk Assessment
**Risk Level**: VERY LOW
- Only text changes in display function
- No functional changes to commands themselves
- All tests passing

Fixes: #hotfix-9