### PR TITLE
fix: cache nix store size async and decouple /metrics timeout race (#224)

### DIFF
--- a/scripts/health-api.py
+++ b/scripts/health-api.py
@@ -7,6 +7,7 @@ import subprocess
 import os
 import socket
 import hmac
+import threading
 import time
 from datetime import datetime, timezone
 from http.server import HTTPServer, BaseHTTPRequestHandler
@@ -120,11 +121,50 @@ def check_generations() -> dict:
         return {"status": "warn", "count": 0}
 
 
-def check_nix_store() -> dict:
-    # du -sh /nix/store can take 30-60+ seconds on large stores
-    # Use a short timeout — store size is non-critical and shouldn't block the response
+# ---------------------------------------------------------------------------
+# Nix store size — cached asynchronously to avoid blocking /health
+# `du -sh /nix/store` takes 10+ seconds on large stores and used to run on
+# every /health request.  A daemon thread refreshes the value every
+# NIX_STORE_CACHE_TTL seconds off the request critical path, so check_nix_store()
+# returns instantly from the cache.  Stale data is acceptable here — store size
+# is a diagnostic signal, not a real-time metric.
+# ---------------------------------------------------------------------------
+_nix_store_cache: dict = {}
+_nix_store_cache_time: float = 0.0
+_nix_store_lock = threading.Lock()
+NIX_STORE_CACHE_TTL = 300  # seconds (5 minutes)
+
+
+def _refresh_nix_store_cache() -> None:
+    """Run du -sh /nix/store and populate the cache. Safe to call from any thread."""
+    global _nix_store_cache, _nix_store_cache_time  # noqa: PLW0603
     size = run("du -sh /nix/store 2>/dev/null | cut -f1", timeout=10)
-    return {"size": size or "timed out"}
+    with _nix_store_lock:
+        _nix_store_cache = {"size": size or "timed out"}
+        _nix_store_cache_time = time.monotonic()
+
+
+def _nix_store_refresher() -> None:
+    """Daemon-thread loop that refreshes the cache every NIX_STORE_CACHE_TTL seconds."""
+    while True:
+        try:
+            _refresh_nix_store_cache()
+        except Exception:
+            # Never let the refresher thread die — leave last-good cache in place
+            pass
+        time.sleep(NIX_STORE_CACHE_TTL)
+
+
+def check_nix_store() -> dict:
+    """Return the cached nix store size. Non-blocking.
+
+    Returns {"size": "pending", ...} if the background refresher has not yet
+    produced a first sample. Otherwise returns the last cached value.
+    """
+    with _nix_store_lock:
+        if not _nix_store_cache:
+            return {"size": "pending", "detail": "first sample in progress"}
+        return dict(_nix_store_cache)
 
 
 def detect_profile(launchctl_output: str) -> str:
@@ -251,40 +291,60 @@ _metrics_cache: dict = {}
 _metrics_cache_time: float = 0.0
 METRICS_CACHE_TTL = 2  # seconds
 
+# Last known-good mactop sample, used as a fallback when mactop times out or
+# errors.  Returning slightly-stale data is far more useful than an error for
+# the /metrics endpoint, which is consumed by dashboards and health-check.sh.
+_metrics_last_good: dict = {}
+_metrics_last_good_time: float = 0.0
+
+
+def _stale_metrics_fallback(error_detail: str) -> dict:
+    """Return the last-good metrics sample marked stale, or the error dict if none."""
+    if _metrics_last_good:
+        stale = dict(_metrics_last_good)
+        stale["stale"] = True
+        stale["stale_age_seconds"] = round(time.monotonic() - _metrics_last_good_time, 1)
+        stale["stale_reason"] = error_detail
+        return stale
+    return {"status": "error", "detail": error_detail}
+
 
 def get_system_metrics() -> dict:
     """Return Apple Silicon metrics from mactop (CPU, GPU, memory, thermal, power).
 
     Calls `mactop --headless --format json --count 1` and reshapes the output
     into a clean API response.  Results are cached for METRICS_CACHE_TTL seconds.
+    On mactop timeout/error, returns the last-good sample marked as stale
+    (or an error dict if no sample has ever succeeded).
     """
     global _metrics_cache, _metrics_cache_time  # noqa: PLW0603
+    global _metrics_last_good, _metrics_last_good_time  # noqa: PLW0603
     now = time.monotonic()
     if _metrics_cache and (now - _metrics_cache_time) < METRICS_CACHE_TTL:
         return _metrics_cache
 
     mactop_bin = "/opt/homebrew/bin/mactop"
     if not os.path.isfile(mactop_bin):
-        return {"status": "error", "detail": "mactop not installed"}
+        return _stale_metrics_fallback("mactop not installed")
 
     try:
         result = subprocess.run(
             [mactop_bin, "--headless", "--format", "json", "--count", "1"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True, text=True, timeout=3,
         )
         if result.returncode != 0 or not result.stdout.strip():
-            return {"status": "error", "detail": f"mactop failed: {result.stderr.strip()[:200]}"}
+            return _stale_metrics_fallback(f"mactop failed: {result.stderr.strip()[:200]}")
     except subprocess.TimeoutExpired:
-        return {"status": "error", "detail": "mactop timed out (5s)"}
+        return _stale_metrics_fallback("mactop timed out (3s)")
     except Exception as e:
-        return {"status": "error", "detail": str(e)[:200]}
+        return _stale_metrics_fallback(str(e)[:200])
 
     try:
         raw = json.loads(result.stdout)
         # mactop returns a JSON array; take first sample
         sample = raw[0] if isinstance(raw, list) else raw
     except (json.JSONDecodeError, IndexError) as e:
-        return {"status": "error", "detail": f"mactop JSON parse error: {e}"}
+        return _stale_metrics_fallback(f"mactop JSON parse error: {e}")
 
     mem = sample.get("memory", {})
     soc = sample.get("soc_metrics", {})
@@ -358,6 +418,8 @@ def get_system_metrics() -> dict:
 
     _metrics_cache = response
     _metrics_cache_time = now
+    _metrics_last_good = response
+    _metrics_last_good_time = now
     return response
 
 
@@ -414,6 +476,14 @@ class ThreadedHTTPServer(ThreadingMixIn, HTTPServer):
 
 
 def main():
+    # Start the nix-store refresher daemon before serving so /health never blocks
+    # on `du -sh /nix/store`. It runs an initial refresh immediately and then
+    # sleeps for NIX_STORE_CACHE_TTL seconds between refreshes.
+    refresher = threading.Thread(
+        target=_nix_store_refresher, name="nix-store-refresher", daemon=True
+    )
+    refresher.start()
+
     server = ThreadedHTTPServer(("0.0.0.0", PORT), HealthHandler)
     print(f"Health API listening on 0.0.0.0:{PORT}")
     try:

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -455,7 +455,10 @@ fi
 # Check 14: System metrics (Apple Silicon vitals via health-api /metrics)
 # ---------------------------------------------------------------------------
 echo "Checking system metrics..."
-METRICS_JSON=$(curl -s --connect-timeout 3 --max-time 5 http://localhost:7780/metrics 2>/dev/null || true)
+# --max-time must exceed health-api.py mactop subprocess timeout (3s) plus request
+# overhead; 8s leaves comfortable headroom so curl never aborts before Python
+# can write the response (issue #224).
+METRICS_JSON=$(curl -s --connect-timeout 3 --max-time 8 http://localhost:7780/metrics 2>/dev/null || true)
 if [[ -n "${METRICS_JSON}" ]]; then
     METRICS_SUMMARY=$(echo "${METRICS_JSON}" | python3 -c "
 import json, sys
@@ -489,8 +492,17 @@ except:
             ;;
     esac
 else
-    print_status "info" "System metrics: health-api not responding on port 7780"
-    echo "    → Run: launchctl start org.nixos.health-api"
+    # Empty response from /metrics could mean two different things:
+    #   1. The server is up but the request timed out (e.g. mactop slow)
+    #   2. The port isn't listening at all (LaunchAgent down)
+    # A quick /ping probe with a tight timeout distinguishes the two so the
+    # operator gets actionable advice instead of a misleading generic error.
+    if curl -s --connect-timeout 1 --max-time 2 http://localhost:7780/ping > /dev/null 2>&1; then
+        print_status "warn" "System metrics: request timed out (server alive — see /tmp/health-api.err)"
+    else
+        print_status "info" "System metrics: health-api not responding on port 7780"
+        echo "    → Run: launchctl start org.nixos.health-api"
+    fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #224 — `/health` blocked ~10 s every request because `check_nix_store()` ran `du -sh /nix/store` synchronously, and the `/metrics` CLI probe raced its own upstream timeout, producing a misleading "health-api not responding" message even though the server was fine.

## Changes

**`scripts/health-api.py`** — addresses Bug 1 + half of Bug 2:
- New daemon thread refreshes the nix store size every 5 minutes off the request critical path. `check_nix_store()` now returns the cached value immediately (or `{"size": "pending"}` on the very first request before the first sample completes). Mirrors the existing `_metrics_cache` pattern.
- Lowered `mactop` subprocess timeout from 5 s → 3 s.
- Added `_metrics_last_good` last-successful-sample fallback: when `mactop` times out or fails, return the last good sample tagged `"stale": true` with `"stale_age_seconds"` instead of a bare error.

**`scripts/health-check.sh`** — addresses other half of Bug 2:
- Bumped `/metrics` curl `--max-time 5` → `--max-time 8`.
- Rewrote the empty-response branch to probe `/ping` first so operators can distinguish "port not listening" from "request timed out (server alive)".

```
 2 files changed, 95 insertions(+), 13 deletions(-)
```

## Validation

- `python3 -c "import ast; ast.parse(...)"` → OK
- `bash -n scripts/health-check.sh` → OK
- `shellcheck scripts/health-check.sh` → 5 warnings, all pre-existing (none in modified regions)
- `nix flake check --no-build` → all checks passed
- Module smoke-test: imports cleanly, all new globals present, `check_nix_store()` returns expected shape on cold start.

## Test plan (to be run by FX)

- [ ] `rebuild` to deploy the new `~/.local/bin/health-api.py`
- [ ] `launchctl bootout gui/501/org.nixos.health-api && launchctl bootstrap gui/501 ~/Library/LaunchAgents/org.nixos.health-api.plist` to restart the agent
- [ ] First `/health` call should return ~immediately with `size: "pending"`; subsequent calls (after ~30 s for the background thread to populate) should show real size
- [ ] `time curl -s http://localhost:7780/health > /dev/null` consistently <1 s
- [ ] `health-check` should no longer print "health-api not responding" — either show vitals or a clearly distinguished "request timed out" / "port not listening" message
- [ ] Regression: ensure `/ping`, `/health`, and `/metrics` all return well-formed JSON

Fixes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)