### PR TITLE
feat(shell): ollama-warm / ollama-evict helpers (#246)

### DIFF
--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -92,6 +92,28 @@ Activate apps requiring sign-in or license keys. See [Licensed Apps Guide](./lic
   ollama run gpt-oss:20b "Hello, how are you?"
   ```
 
+#### Managing Ollama model residency
+
+Two shell helpers provide explicit control over whether a model stays
+loaded in RAM, complementing the profile-tuned `OLLAMA_KEEP_ALIVE`
+default (see `darwin/maintenance.nix`):
+
+- `ollama-warm <model>` — pins the model in RAM (`keep_alive=-1`) until
+  evicted. Useful before a session of heavy use so the first request
+  doesn't pay the cold-load penalty.
+- `ollama-evict [model]` — unloads one model, or all loaded models if
+  no argument is given. Inspect loaded models first with `ollama ps`.
+
+```bash
+ollama-warm gemma4:26b     # Pin before a coding session
+ollama ps                  # See what's loaded
+ollama-evict gemma4:26b    # Free the RAM
+ollama-evict               # Unload everything currently loaded
+```
+
+Both commands refuse if the Ollama daemon isn't running on
+`localhost:11434`.
+
 ### Raycast Configuration
 
 - [ ] **Set Raycast hotkey**

--- a/home-manager/modules/shell.nix
+++ b/home-manager/modules/shell.nix
@@ -379,6 +379,67 @@
       }
 
       # =============================================================================
+      # OLLAMA MODEL RESIDENCY HELPERS (Story 08.2-003)
+      # =============================================================================
+      # Explicit control over Ollama model in-RAM residency, complementing the
+      # automatic OLLAMA_KEEP_ALIVE behavior tuned in darwin/maintenance.nix.
+
+      # Pin a model in RAM until evicted (keep_alive=-1).
+      # Usage: ollama-warm <model>
+      # Example: ollama-warm gemma4:26b
+      ollama-warm() {
+        local model="''${1:-}"
+        if [[ -z "$model" ]]; then
+          echo "usage: ollama-warm <model>" >&2
+          return 2
+        fi
+        if ! curl -sf -o /dev/null http://localhost:11434/api/version; then
+          echo "✗ Ollama daemon not responding on localhost:11434" >&2
+          return 1
+        fi
+        if curl -sf -o /dev/null http://localhost:11434/api/generate \
+             -d "{\"model\":\"$model\",\"prompt\":\"\",\"keep_alive\":-1}"; then
+          echo "✓ Warmed: $model (keep_alive=-1 until evicted)"
+        else
+          echo "✗ Failed to warm $model — is the tag valid? 'ollama list'" >&2
+          return 1
+        fi
+      }
+
+      # Evict one model, or all loaded models if no arg given.
+      # Usage: ollama-evict [model]
+      ollama-evict() {
+        local target="''${1:-}"
+        if ! curl -sf -o /dev/null http://localhost:11434/api/version; then
+          echo "✗ Ollama daemon not responding on localhost:11434" >&2
+          return 1
+        fi
+        if [[ -n "$target" ]]; then
+          if curl -sf -o /dev/null http://localhost:11434/api/generate \
+               -d "{\"model\":\"$target\",\"keep_alive\":0}"; then
+            echo "✓ Evicted: $target"
+          else
+            echo "✗ Failed to evict $target" >&2
+            return 1
+          fi
+        else
+          # No arg: evict every loaded model
+          local loaded
+          loaded=$(ollama ps 2>/dev/null | awk 'NR>1 {print $1}')
+          if [[ -z "$loaded" ]]; then
+            echo "No models currently loaded."
+            return 0
+          fi
+          while IFS= read -r m; do
+            curl -sf -o /dev/null http://localhost:11434/api/generate \
+              -d "{\"model\":\"$m\",\"keep_alive\":0}" \
+              && echo "✓ Evicted: $m" \
+              || echo "✗ Failed to evict: $m" >&2
+          done <<< "$loaded"
+        fi
+      }
+
+      # =============================================================================
       # ZSH OPTIONS (Story 04.1-003)
       # =============================================================================
 


### PR DESCRIPTION
## Summary
Two zsh helpers in `shell.nix` `initContent` for explicit Ollama model residency control:

- `ollama-warm <model>` — pins a model in RAM (`keep_alive=-1`) until evicted
- `ollama-evict [model]` — unloads one model, or every loaded model if no arg

Both guard against the daemon being down by probing `/api/version` first and exiting 1 with a clear message when it's not responding.

Complements the profile-tuned `OLLAMA_KEEP_ALIVE` in upcoming #244 (08.2-001) — those set sane defaults, these let FX explicitly override when workflow demands it (warm before a long coding session; evict to reclaim RAM).

Also documented in `docs/post-install.md` under a new "Managing Ollama model residency" subsection.

## Test plan
- [ ] `ollama-warm` (no arg) → exits with usage error
- [ ] `ollama-warm gemma4:26b` while daemon up → warms; `ollama ps` shows entry with `Forever`
- [ ] `ollama-evict gemma4:26b` → unloads; `ollama ps` empty
- [ ] `ollama-evict` (no arg) with models loaded → unloads all
- [ ] `ollama-evict` with no models loaded → "No models currently loaded."
- [ ] Daemon stopped (`pkill -x ollama`) → both commands exit 1 with clear message
- [ ] `nix-instantiate --parse home-manager/modules/shell.nix` passes (verified)

## Risk
Low — purely additive shell functions, no config changes.

Implements Story 08.2-003, closes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)