### PR TITLE
feat(claude-cleanup): --prune-old mode + weekly LaunchAgent (#241)

### DIFF
--- a/darwin/maintenance.nix
+++ b/darwin/maintenance.nix
@@ -210,6 +210,35 @@ in {
     };
 
     # =========================================================================
+    # CLAUDE PROJECT PRUNING (Story 08.1-006)
+    # =========================================================================
+    # Runs weekly on Saturday at 5:00 AM to remove stale project transcripts
+    # from ~/.claude/projects/ that have been untouched for
+    # CLAUDE_RETENTION_DAYS days (default 90). Always preserves any path
+    # containing a memory/ subdir (auto-memory persists across conversations).
+    #
+    # User can opt-out specific projects by setting
+    # userConfig.claudeProjectsKeep = [ "project-name-1" "project-name-2" ];
+    # (colon-joined into CLAUDE_PROJECTS_KEEP env var).
+    claude-project-prune = mkScheduledAgent {
+      name = "claude-project-prune";
+      schedule = { Weekday = 6; Hour = 5; Minute = 0; };
+      env = {
+        CLAUDE_PROJECTS_KEEP = builtins.concatStringsSep ":"
+          (userConfig.claudeProjectsKeep or []);
+      };
+      command = ''
+        SCRIPT="${scriptsDir}/claude-cleanup.sh"
+        if [[ -x "$SCRIPT" ]]; then
+          "$SCRIPT" --prune-old
+        else
+          echo "Claude cleanup script not found: $SCRIPT" >> /tmp/claude-project-prune.err
+          exit 1
+        fi
+      '';
+    };
+
+    # =========================================================================
     # OLLAMA SERVER (Network-accessible via Tailscale)
     # =========================================================================
     # Starts Ollama server at login bound to all interfaces (0.0.0.0)

--- a/scripts/claude-cleanup.sh
+++ b/scripts/claude-cleanup.sh
@@ -1,17 +1,26 @@
 #!/usr/bin/env bash
-# ABOUTME: Kills orphaned Claude Code MCP / node server processes to mitigate kernel memory leaks
-# ABOUTME: Runs every 90 minutes via LaunchAgent (see darwin/maintenance.nix: claude-code-cleanup)
+# ABOUTME: Two-mode Claude Code maintenance: orphan-process killer + stale-project pruner
+# ABOUTME: Default mode (no arg) runs the orphan killer — invoked every 90 minutes via LaunchAgent
 #
 # Background: Running many parallel Claude Code agents on macOS leaks kernel
 # memory in the kalloc.1024 zone and leaves orphaned Node subprocesses behind
-# when Claude Code crashes or is force-quit. This script only targets processes
-# that have been re-parented to launchd (PPID=1) — i.e. truly orphaned — so
-# MCP servers of live Claude Code sessions are left alone.
+# when Claude Code crashes or is force-quit. The orphan killer targets processes
+# re-parented to launchd (PPID=1) only, so MCP servers of live sessions are
+# left alone.
+#
+# The --prune-old mode addresses a different growth axis: ~/.claude/projects/
+# accumulates transcript dirs indefinitely. This mode removes project dirs
+# untouched for N days (default 90) while ALWAYS preserving any path that
+# contains a memory/ subdir (auto-memory persists across conversations).
 
 set -euo pipefail
 
 LOG_FILE="${HOME}/.claude/cleanup.log"
 mkdir -p "$(dirname "${LOG_FILE}")"
+
+# ---------------------------------------------------------------------------
+# Orphan process killer (default mode)
+# ---------------------------------------------------------------------------
 
 # Patterns matching Claude Code spawned Node processes
 PATTERNS=(
@@ -26,23 +35,169 @@ orphan_pids() {
         | awk -v pat="${pattern}" '$2 == 1 && $0 ~ pat { print $1 }'
 }
 
-killed=0
-for pattern in "${PATTERNS[@]}"; do
-    pids=$(orphan_pids "${pattern}")
-    [[ -z "${pids}" ]] && continue
+kill_orphans() {
+    local killed=0
+    for pattern in "${PATTERNS[@]}"; do
+        local pids
+        pids=$(orphan_pids "${pattern}")
+        [[ -z "${pids}" ]] && continue
 
-    # Graceful TERM, wait, then forceful KILL on anything that survived
-    echo "${pids}" | xargs kill -TERM 2>/dev/null || true
-    sleep 2
+        # Graceful TERM, wait, then forceful KILL on anything that survived
+        echo "${pids}" | xargs kill -TERM 2>/dev/null || true
+        sleep 2
 
-    leftover=$(orphan_pids "${pattern}")
-    if [[ -n "${leftover}" ]]; then
-        echo "${leftover}" | xargs kill -KILL 2>/dev/null || true
+        local leftover
+        leftover=$(orphan_pids "${pattern}")
+        if [[ -n "${leftover}" ]]; then
+            echo "${leftover}" | xargs kill -KILL 2>/dev/null || true
+        fi
+
+        # shellcheck disable=SC2086  # intentional word-splitting to count PIDs
+        killed=$((killed + $(echo ${pids} | wc -w)))
+    done
+
+    printf '%s cleaned %d orphaned Claude Code processes\n' \
+        "$(date '+%Y-%m-%d %H:%M:%S')" "${killed}" >> "${LOG_FILE}"
+}
+
+# ---------------------------------------------------------------------------
+# Stale-project pruner (--prune-old)
+# ---------------------------------------------------------------------------
+
+# Return 0 if the given directory contains any memory/ subdir (anywhere), else 1.
+# memory/ is Claude Code's auto-memory store — must never be removed.
+has_memory_dir() {
+    local dir="$1"
+    [[ -n "$(find "${dir}" -type d -name memory -print -quit 2>/dev/null)" ]]
+}
+
+# Return 0 if the given project base-name is in CLAUDE_PROJECTS_KEEP (colon-separated).
+is_kept() {
+    local name="$1"
+    local keep_list="${CLAUDE_PROJECTS_KEEP:-}"
+    [[ -z "${keep_list}" ]] && return 1
+    local IFS=':'
+    # shellcheck disable=SC2206
+    local kept=(${keep_list})
+    for k in "${kept[@]}"; do
+        [[ "${k}" == "${name}" ]] && return 0
+    done
+    return 1
+}
+
+prune_old_projects() {
+    local retention_days="${CLAUDE_RETENTION_DAYS:-90}"
+    local projects_dir="${HOME}/.claude/projects"
+    local archive_dir="${HOME}/.claude/archive"
+    local dry_run="${1:-}"
+
+    if [[ ! -d "${projects_dir}" ]]; then
+        echo "No ~/.claude/projects directory — nothing to prune."
+        return 0
     fi
 
-    # shellcheck disable=SC2086  # intentional word-splitting to count PIDs
-    killed=$((killed + $(echo ${pids} | wc -w)))
-done
+    mkdir -p "${archive_dir}"
+    local manifest="${archive_dir}/pruned-$(date '+%Y-%m-%d').txt"
 
-printf '%s cleaned %d orphaned Claude Code processes\n' \
-    "$(date '+%Y-%m-%d %H:%M:%S')" "${killed}" >> "${LOG_FILE}"
+    local pruned=0
+    local skipped_memory=0
+    local skipped_kept=0
+    local scanned=0
+
+    # find ... -mtime +N gives dirs whose contents haven't changed in N days.
+    # -maxdepth 1 to list only top-level project dirs under projects/.
+    while IFS= read -r -d '' project; do
+        scanned=$((scanned + 1))
+        local name
+        name=$(basename "${project}")
+
+        if is_kept "${name}"; then
+            skipped_kept=$((skipped_kept + 1))
+            [[ -n "${dry_run}" ]] && echo "KEEP (config): ${name}"
+            continue
+        fi
+
+        if has_memory_dir "${project}"; then
+            skipped_memory=$((skipped_memory + 1))
+            [[ -n "${dry_run}" ]] && echo "KEEP (memory/): ${name}"
+            continue
+        fi
+
+        if [[ -n "${dry_run}" ]]; then
+            echo "WOULD PRUNE: ${name}"
+        else
+            {
+                echo "pruned=${name}"
+                echo "  mtime=$(stat -f '%Sm' "${project}")"
+                echo "  size=$(du -sh "${project}" 2>/dev/null | cut -f1)"
+            } >> "${manifest}"
+            rm -rf "${project}"
+            pruned=$((pruned + 1))
+        fi
+    done < <(find "${projects_dir}" -mindepth 1 -maxdepth 1 -type d -mtime "+${retention_days}" -print0 2>/dev/null)
+
+    if [[ -n "${dry_run}" ]]; then
+        printf 'DRY-RUN: would prune %d/%d projects (%d kept via config, %d via memory/)\n' \
+            "${pruned}" "${scanned}" "${skipped_kept}" "${skipped_memory}"
+    else
+        printf '%s pruned %d Claude projects (>%dd old); kept %d via config, %d via memory/; manifest: %s\n' \
+            "$(date '+%Y-%m-%d %H:%M:%S')" "${pruned}" "${retention_days}" \
+            "${skipped_kept}" "${skipped_memory}" "${manifest}" >> "${LOG_FILE}"
+        echo "✓ Pruned ${pruned} project dir(s); manifest at ${manifest}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [command]
+
+Commands:
+    (no arg)     Kill orphaned Claude Code MCP / Node processes (default;
+                 invoked by the 90-minute LaunchAgent)
+    --prune-old  Remove ~/.claude/projects/ dirs not modified in
+                 \$CLAUDE_RETENTION_DAYS days (default: 90). Always
+                 preserves any path containing a memory/ subdir.
+    --dry-run    With --prune-old: list what would be removed, no changes.
+    --help, -h   This message.
+
+Env:
+    CLAUDE_RETENTION_DAYS    Retention window for --prune-old (default: 90)
+    CLAUDE_PROJECTS_KEEP     Colon-separated project names to never prune
+                             (e.g., "important-project:nix-install")
+EOF
+}
+
+main() {
+    local mode="${1:-}"
+    case "${mode}" in
+        "" | orphans)
+            kill_orphans
+            ;;
+        --prune-old)
+            local dry=""
+            [[ "${2:-}" == "--dry-run" ]] && dry="dry-run"
+            prune_old_projects "${dry}"
+            ;;
+        --dry-run)
+            # Support --dry-run --prune-old ordering too
+            [[ "${2:-}" == "--prune-old" ]] && prune_old_projects "dry-run" || {
+                echo "--dry-run requires --prune-old" >&2
+                exit 2
+            }
+            ;;
+        --help|-h|help)
+            usage
+            ;;
+        *)
+            echo "Unknown command: ${mode}" >&2
+            usage
+            exit 2
+            ;;
+    esac
+}
+
+main "$@"

--- a/user-config.template.nix
+++ b/user-config.template.nix
@@ -21,4 +21,11 @@
   directories = {
     dotfiles = "@DOTFILES_PATH@";  # Nix configuration repository location
   };
+
+  # Claude Code project retention
+  # Projects under ~/.claude/projects/ untouched for 90 days are pruned
+  # weekly by the claude-project-prune LaunchAgent (Story 08.1-006).
+  # Any path containing a memory/ subdir is preserved automatically.
+  # List project dir names here to preserve them even without memory/.
+  # claudeProjectsKeep = [ "important-project" "long-running-research" ];
 }


### PR DESCRIPTION
## Summary
Two-mode `claude-cleanup.sh`: existing orphan-process killer unchanged (still invoked every 90 minutes), new `--prune-old` removes `~/.claude/projects/` dirs untouched for 90 days while **always** preserving paths with a `memory/` subdir.

~/.claude is currently 1.2 GB on Power profile with years of transcript accumulation; memory/ is Claude Code's auto-memory store, which must never be touched.

## Safety model
- **`memory/` preservation**: `find <project> -type d -name memory -print -quit` — if non-empty, skip entire project dir
- **Explicit opt-out**: `CLAUDE_PROJECTS_KEEP="a:b:c"` env var (colon-separated project names)
- **Manifest per run**: `~/.claude/archive/pruned-YYYY-MM-DD.txt` records each pruned dir's mtime and size
- **Dry-run**: `claude-cleanup.sh --prune-old --dry-run` lists candidates without deleting (order of flags doesn't matter)

## Changes
- `scripts/claude-cleanup.sh`: refactored into subcommand dispatch, added `prune_old_projects()`, `has_memory_dir()`, `is_kept()`, `usage()`
- `darwin/maintenance.nix`: new `claude-project-prune` LaunchAgent via `mkScheduledAgent`, Saturday 5 AM, threads `userConfig.claudeProjectsKeep or []` → `CLAUDE_PROJECTS_KEEP` env
- `user-config.template.nix`: commented documentation of the new optional `claudeProjectsKeep` attr

## Test plan
- [ ] `claude-cleanup.sh` (no arg) still kills orphans as before — backward compat check
- [ ] `claude-cleanup.sh --prune-old --dry-run` lists stale projects, flags kept/memory-protected ones
- [ ] Create a test project dir with `memory/` subdir, set mtime to 100 days ago → survives prune
- [ ] Create test project without `memory/`, 100 days old → pruned, manifest has entry
- [ ] `CLAUDE_PROJECTS_KEEP=test-proj claude-cleanup.sh --prune-old --dry-run` → `test-proj` kept
- [ ] After rebuild: `launchctl list | grep claude-project-prune` shows loaded
- [ ] `nix-instantiate --parse darwin/maintenance.nix` passes (verified)

## Risk
Low — memory/ protection is the first check in the loop; kept-list is colon-joined from user-config with default `[]`; dry-run available for validation before first real prune.

Implements Story 08.1-006, closes #241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)