### PR TITLE
feat(ollama): tune memory residency via LaunchAgent env (#244)

### DIFF
--- a/darwin/maintenance.nix
+++ b/darwin/maintenance.nix
@@ -6,6 +6,7 @@
   pkgs,
   lib,
   userConfig,
+  profileName,
   ...
 }: let
   # Scripts are installed to ~/.local/bin to avoid macOS TCC (Transparency, Consent, Control)
@@ -17,6 +18,22 @@
   # NOTE: Only one * per origin pattern (gin-contrib/cors limitation in Ollama 0.15+)
   ollamaHost = "0.0.0.0";
   ollamaOrigins = "http://localhost:*,http://127.0.0.1:*,http://100.*";
+
+  # Ollama memory-residency tuning (Story 08.2-001).
+  # MAX_LOADED_MODELS=1: second model evicts the first (prevents 20+ GB RAM pin)
+  # NUM_PARALLEL=1: one in-flight request — avoids speculative memory allocation
+  # KEEP_ALIVE: profile-scoped idle timeout before model unloads
+  #   - power: 5m (chat sessions, 26B model worth keeping resident)
+  #   - standard: 2m (mid-size models, shorter sessions)
+  #   - ai-assistant: 30s (embeddings-only; unload aggressively)
+  # User can override KEEP_ALIVE via userConfig.ollamaKeepAlive attr.
+  ollamaMaxLoadedModels = "1";
+  ollamaNumParallel = "1";
+  ollamaKeepAlive = userConfig.ollamaKeepAlive or (
+    if profileName == "power" then "5m"
+    else if profileName == "ai-assistant" then "30s"
+    else "2m"
+  );
 
   # Standard PATH for scheduled LaunchAgents (includes per-user Nix profile)
   agentPath = "/etc/profiles/per-user/${userConfig.username}/bin:/run/current-system/sw/bin:/usr/bin:/bin";
@@ -257,6 +274,9 @@ in {
       env = {
         OLLAMA_HOST = ollamaHost;
         OLLAMA_ORIGINS = ollamaOrigins;
+        OLLAMA_MAX_LOADED_MODELS = ollamaMaxLoadedModels;
+        OLLAMA_NUM_PARALLEL = ollamaNumParallel;
+        OLLAMA_KEEP_ALIVE = ollamaKeepAlive;
         PATH = "/opt/homebrew/bin:/run/current-system/sw/bin:/usr/bin:/bin";
       };
       command = ''
@@ -272,7 +292,10 @@ in {
 
   # Global environment variables for Ollama
   # Ensures any manually started Ollama server (e.g., `ollama serve` from terminal)
-  # also binds to all interfaces for Tailscale accessibility
+  # also picks up the tuned memory-residency behavior.
   environment.variables.OLLAMA_HOST = ollamaHost;
   environment.variables.OLLAMA_ORIGINS = ollamaOrigins;
+  environment.variables.OLLAMA_MAX_LOADED_MODELS = ollamaMaxLoadedModels;
+  environment.variables.OLLAMA_NUM_PARALLEL = ollamaNumParallel;
+  environment.variables.OLLAMA_KEEP_ALIVE = ollamaKeepAlive;
 }

--- a/user-config.template.nix
+++ b/user-config.template.nix
@@ -28,4 +28,9 @@
   # Any path containing a memory/ subdir is preserved automatically.
   # List project dir names here to preserve them even without memory/.
   # claudeProjectsKeep = [ "important-project" "long-running-research" ];
+
+  # Ollama keep-alive override (Story 08.2-001)
+  # Defaults: power "5m", standard "2m", ai-assistant "30s".
+  # Uncomment to override — format matches Go duration strings.
+  # ollamaKeepAlive = "10m";
 }


### PR DESCRIPTION
## Summary
Eliminates the ~3 GB swap + 11 GB compressor baseline caused by default Ollama behavior. Sets `OLLAMA_MAX_LOADED_MODELS=1`, `OLLAMA_NUM_PARALLEL=1`, and a profile-scoped `OLLAMA_KEEP_ALIVE` so a single call doesn't pin 17 GB for 5 minutes while unrelated workloads trigger swap.

## Per-profile keep-alive
| Profile | `OLLAMA_KEEP_ALIVE` | Rationale |
|---------|---:|---|
| power | `5m` | 26B chat sessions worth keeping resident briefly |
| standard | `2m` | Mid-size models, shorter sessions |
| ai-assistant | `30s` | Embeddings-only; unload aggressively |

Override via `userConfig.ollamaKeepAlive = "10m"` in `user-config.nix` (documented in template).

## Changes
- `darwin/maintenance.nix`: added `profileName` to module params, set `OLLAMA_MAX_LOADED_MODELS` / `OLLAMA_NUM_PARALLEL` / `OLLAMA_KEEP_ALIVE` on both the `ollama-serve` LaunchAgent env block and the global `environment.variables` (so manually-started `ollama serve` picks them up)
- `user-config.template.nix`: commented `ollamaKeepAlive` override hint

## Test plan
- [ ] `darwin-rebuild switch` picks up new env (no activation script changes required; LaunchAgent reload automatic)
- [ ] `launchctl print gui/$UID/org.nixos.ollama-serve | grep -iE 'KEEP_ALIVE|MAX_LOADED|PARALLEL'` shows the 3 new vars
- [ ] Load gemma4:26b via `ollama run gemma4:26b "hi"`; wait 5m+10s (on power) → `ollama ps` shows empty
- [ ] Load gemma4:e4b → `ollama ps` shows e4b; load gemma4:26b → e4b evicted (MAX_LOADED_MODELS=1)
- [ ] `env | grep OLLAMA_KEEP_ALIVE` in a new shell returns the profile default
- [ ] Set `userConfig.ollamaKeepAlive = "1m"` → rebuild → verify override applied
- [ ] `nix-instantiate --parse darwin/maintenance.nix` passes (verified)

## Risk
Low — env-only change, LaunchAgent reload is automatic, revertible via `darwin-rebuild --rollback`. Worst case: idle model unloads too quickly and next request pays the cold-load penalty — adjustable via `ollamaKeepAlive`.

Implements Story 08.2-001, closes #244.

🤖 Generated with [Claude Code](https://claude.com/claude-code)