### PR TITLE
feat(health): swap-pressure alerting via /metrics status_flags (#248)

### DIFF
--- a/scripts/health-api.py
+++ b/scripts/health-api.py
@@ -21,6 +21,7 @@ GENERATION_WARNING_THRESHOLD = 50   # Warn if more than N system generations
 DISK_WARNING_GB = 20                # Warn if less than N GB free
 CACHE_WARNING_KB = 1_048_576        # 1 GB — warn if any single cache exceeds this
 HF_CACHE_WARNING_KB = 10_485_760    # 10 GB — Huggingface cache grows fastest (model blobs)
+SWAP_WARNING_GB = 2                 # Warn when swap usage exceeds this (signals real memory pressure)
 
 # Expected Ollama models per profile (keep in sync with flake.nix ollamaModels)
 OLLAMA_MODELS = {
@@ -470,6 +471,15 @@ def get_system_metrics() -> dict:
             "state": _thermal_state_from_temps(cpu_temp_c, gpu_temp_c),
         },
     }
+
+    # Status flags: derived signals for dashboards / health-check.sh to key on.
+    # Additive field; absent for backwards compatibility when all checks are OK.
+    swap_used = response["memory"]["swap_used_gb"]
+    status_flags: dict[str, str] = {}
+    if swap_used > SWAP_WARNING_GB:
+        status_flags["memory_swap"] = "warn"
+    if status_flags:
+        response["status_flags"] = status_flags
 
     _metrics_cache = response
     _metrics_cache_time = now

--- a/scripts/health-check.sh
+++ b/scripts/health-check.sh
@@ -25,6 +25,7 @@ GENERATION_WARNING_THRESHOLD=50  # Warn if more than N system generations
 DISK_WARNING_GB=20               # Warn if less than N GB free
 CACHE_WARNING_KB=1048576         # 1 GB — warn if any single cache exceeds this
 HF_CACHE_WARNING_KB=10485760     # 10 GB — Huggingface cache grows fastest (model blobs)
+SWAP_WARNING_GB=2                # Warn when swap usage exceeds this (signals real memory pressure)
 
 # Expected Ollama models per profile (keep in sync with flake.nix ollamaModels)
 # Power: gemma4:e4b, gemma4:26b, nomic-embed-text
@@ -506,15 +507,24 @@ try:
         mem_total = d['memory']['total_gb']
         thermal = d['thermal']['state']
         total_w = d['power']['total_watts']
-        print(f'ok:CPU {cpu}% | GPU {gpu}% | Mem {mem_used:.0f}/{mem_total:.0f}GB | {total_w:.0f}W | Thermal: {thermal}')
+        swap_used = d['memory'].get('swap_used_gb', 0)
+        swap_flag = d.get('status_flags', {}).get('memory_swap', '')
+        print(f'ok:CPU {cpu}% | GPU {gpu}% | Mem {mem_used:.0f}/{mem_total:.0f}GB | {total_w:.0f}W | Thermal: {thermal}|swap={swap_used}|swap_flag={swap_flag}')
 except:
     print('parse_error')
 " 2>/dev/null || echo "parse_error")
 
     case "${METRICS_SUMMARY}" in
         ok:*)
-            VITALS="${METRICS_SUMMARY#ok:}"
+            # Parse trailing swap info (pipe-separated) out of the vitals line
+            VITALS_FULL="${METRICS_SUMMARY#ok:}"
+            VITALS="${VITALS_FULL%%|swap=*}"
+            SWAP_USED="${VITALS_FULL#*|swap=}"; SWAP_USED="${SWAP_USED%%|*}"
+            SWAP_FLAG="${VITALS_FULL##*|swap_flag=}"
             print_status "ok" "System vitals: ${VITALS}"
+            if [[ "${SWAP_FLAG}" == "warn" ]]; then
+                print_status "warn" "Memory pressure: swap in use ${SWAP_USED}GB (>${SWAP_WARNING_GB}GB) → consider ollama-evict or closing apps"
+            fi
             ;;
         error:*)
             DETAIL="${METRICS_SUMMARY#error:}"


### PR DESCRIPTION
## Summary
Surfaces real memory pressure (swap in use >2 GB) via a new `status_flags` field on `/metrics` and an actionable line in `health-check`. Additive — the field is only present when a flag fires, so existing JSON consumers are unaffected.

## Design choice
The `/metrics` response shape is now:
```json
{
  "memory": { "swap_used_gb": 3.1, ... },
  ...
  "status_flags": { "memory_swap": "warn" }
}
```
`status_flags` is omitted when no flags apply — backwards compatible. Threshold constant `SWAP_WARNING_GB=2` lives in both files and is documented as shared (matches the pattern for GENERATION/DISK/CACHE thresholds already in place).

`health-check` prints the normal vitals line first, then adds a warn line only when the flag fires, suggesting `ollama-evict` or closing apps.

## Test plan
- [ ] Idle system (no swap): `curl -s localhost:7780/metrics | jq .status_flags` → `null`
- [ ] `health-check` under low pressure: shows `System vitals: ...` only, no swap warning
- [ ] Induce swap: `stress-ng --vm 4 --vm-bytes 12G` for ~60s → `/metrics` returns `status_flags.memory_swap: "warn"`, `health-check` adds `Memory pressure: swap in use X.XGB`
- [ ] Close stressor, wait → flag clears on next /metrics refresh (2s TTL)
- [ ] `python3 -c 'import ast; ast.parse(open("scripts/health-api.py").read())'` passes (verified)
- [ ] `bash -n scripts/health-check.sh` passes (verified)

## Risk
Low — purely additive fields, threshold constant shared via comment discipline, no impact on existing consumers.

Implements Story 08.2-005, closes #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)