### PR TITLE
feat(docker): quarterly deep-prune LaunchAgent (#240)

### DIFF
--- a/darwin/maintenance.nix
+++ b/darwin/maintenance.nix
@@ -173,6 +173,76 @@ in {
     };
 
     # =========================================================================
+    # DOCKER QUARTERLY DEEP PRUNE (Story 08.1-005)
+    # =========================================================================
+    # Runs quarterly (1st of Jan/Apr/Jul/Oct at 4:30 AM) to deep-clean Docker's
+    # build cache, orphan volumes, and dangling images — catching the long-tail
+    # that monthly `docker system prune` misses. On Power profile, Docker's
+    # container VM dir can reach 13+ GB of reclaimable space.
+    #
+    # Safe by design: skips cleanly if
+    #   - Docker binary not installed (ai-assistant profile)
+    #   - Docker Desktop isn't running
+    #   - Any containers are currently up (to avoid surprising active workloads)
+    #
+    # Defined directly (not via mkScheduledAgent) because the helper only
+    # supports a single schedule entry; this needs four.
+    docker-deep-prune = {
+      serviceConfig = {
+        Label = "org.nixos.docker-deep-prune";
+        ProgramArguments = [
+          "/bin/bash" "-c"
+          ''
+            LOG=/tmp/docker-deep-prune.log
+            echo "=== Docker Deep Prune $(date '+%Y-%m-%d %H:%M:%S') ===" >> "$LOG"
+
+            if ! command -v docker >/dev/null 2>&1; then
+              echo "✓ Docker not installed — skipping" >> "$LOG"
+              exit 0
+            fi
+
+            if ! docker info >/dev/null 2>&1; then
+              echo "✓ Docker Desktop not running — skipping" >> "$LOG"
+              exit 0
+            fi
+
+            running=$(docker ps -q 2>/dev/null | wc -l | tr -d ' ')
+            if [[ "$running" != "0" ]]; then
+              echo "⊘ $running container(s) running — skipping to avoid disruption" >> "$LOG"
+              exit 0
+            fi
+
+            before=$(docker system df --format '{{.Size}}' 2>/dev/null | paste -sd ' ' -)
+            echo "Before: $before" >> "$LOG"
+
+            docker builder prune --all -f 2>&1 | tail -5 >> "$LOG" || true
+            docker volume prune -f 2>&1 | tail -5 >> "$LOG" || true
+            docker system prune -a --volumes -f 2>&1 | tail -5 >> "$LOG" || true
+
+            after=$(docker system df --format '{{.Size}}' 2>/dev/null | paste -sd ' ' -)
+            echo "After:  $after" >> "$LOG"
+            echo "---" >> "$LOG"
+          ''
+        ];
+        # Fire 1st of Jan/Apr/Jul/Oct at 04:30 (quarterly cadence)
+        StartCalendarInterval = [
+          { Month = 1;  Day = 1; Hour = 4; Minute = 30; }
+          { Month = 4;  Day = 1; Hour = 4; Minute = 30; }
+          { Month = 7;  Day = 1; Hour = 4; Minute = 30; }
+          { Month = 10; Day = 1; Hour = 4; Minute = 30; }
+        ];
+        StandardOutPath = "/tmp/docker-deep-prune.log";
+        StandardErrorPath = "/tmp/docker-deep-prune.err";
+        EnvironmentVariables = {
+          PATH = "/opt/homebrew/bin:${agentPath}";
+          HOME = agentHome;
+        };
+        RunAtLoad = false;
+        Umask = 77;
+      };
+    };
+
+    # =========================================================================
     # CLAUDE CODE ORPHAN CLEANUP
     # =========================================================================
     # Runs every 90 minutes to kill orphaned Claude Code MCP / node server


### PR DESCRIPTION
## Summary
New `docker-deep-prune` LaunchAgent runs on the 1st of each quarter (Jan/Apr/Jul/Oct) at 04:30. Catches Docker's build cache + orphan volumes + dangling images — long-tail reclaimable space that the monthly `disk-cleanup` doesn't deep-prune. On Power profile, this is ~13 GB of reclaimable space today.

## Safety
Skips cleanly (exit 0, logged) in all three cases:
- `docker` binary not installed (ai-assistant profile has no Docker)
- Docker Desktop not running
- Any containers currently up — prevents surprising active workloads

Defined directly (not via `mkScheduledAgent`) because the helper supports only a single `StartCalendarInterval` entry; quarterly needs four.

## Before/after logging
`docker system df --format '{{.Size}}'` captured before and after to `/tmp/docker-deep-prune.log` so each run's reclaim is visible.

## Test plan
- [ ] After rebuild: `launchctl list | grep docker-deep-prune` shows loaded
- [ ] Manual fire: `launchctl start org.nixos.docker-deep-prune` with Docker running + 0 containers → log shows before/after sizes
- [ ] Manual fire with 1+ container running → log says "N container(s) running — skipping"
- [ ] Manual fire with Docker Desktop closed → log says "Docker Desktop not running — skipping"
- [ ] On ai-assistant profile (no Docker installed): log says "Docker not installed — skipping"
- [ ] `nix-instantiate --parse darwin/maintenance.nix` passes (verified)

## Risk
Low — three independent guards, purely cleanup operation, logs every decision. Worst case: a prune races with a just-started container — but `docker ps -q` check closes this window for foreground starts.

Implements Story 08.1-005, closes #240.

🤖 Generated with [Claude Code](https://claude.com/claude-code)