### PR TITLE
feat(ollama): LRU-based stale model pruning (#239)

### DIFF
--- a/darwin/maintenance.nix
+++ b/darwin/maintenance.nix
@@ -260,6 +260,37 @@ in {
     };
 
     # =========================================================================
+    # OLLAMA LRU PRUNE (Story 08.1-004) — OPT-IN
+    # =========================================================================
+    # Monthly non-interactive prune of stale Ollama models (>60 days idle).
+    # Profile-expected models (from flake.nix ollamaModels.*) are ALWAYS
+    # preserved; only extras get removed.
+    #
+    # Opt-in to avoid surprising users who pull a model for a one-off task
+    # and don't want it auto-removed. Enable with:
+    #     # user-config.nix
+    #     enableOllamaLRU = true;
+    #     ollamaLRUThresholdDays = 60;  # optional override
+    ollama-lru =
+      lib.mkIf (userConfig.enableOllamaLRU or false)
+        (mkScheduledAgent {
+          name = "ollama-lru";
+          schedule = { Day = 1; Hour = 5; Minute = 0; };  # 1st of month, 05:00
+          env = {
+            PATH = "/opt/homebrew/bin:${agentPath}";
+          };
+          command = ''
+            SCRIPT="${scriptsDir}/ollama-lru.sh"
+            if [[ -x "$SCRIPT" ]]; then
+              "$SCRIPT" --auto --threshold-days=${toString (userConfig.ollamaLRUThresholdDays or 60)}
+            else
+              echo "ollama-lru script not found: $SCRIPT" >> /tmp/ollama-lru.err
+              exit 1
+            fi
+          '';
+        });
+
+    # =========================================================================
     # CLAUDE CODE ORPHAN CLEANUP
     # =========================================================================
     # Runs every 90 minutes to kill orphaned Claude Code MCP / node server

--- a/home-manager/modules/shell.nix
+++ b/home-manager/modules/shell.nix
@@ -98,6 +98,12 @@
       # Checks Homebrew, nixpkgs, nix-darwin, Ollama for updates and creates GitHub issues
       release-monitor = "bash ${dotfilesPath}/scripts/release-monitor.sh";
 
+      # Ollama LRU model pruning (Story 08.1-004)
+      # --analyze (default): report size + days-since-use for each model
+      # --prune: interactive y/N per stale model
+      # --auto: non-interactive, preserves profile-expected models
+      ollama-lru = "bash ${dotfilesPath}/scripts/ollama-lru.sh";
+
       # =============================================================================
       # GENERAL SHELL ALIASES (Story 04.5-002)
       # =============================================================================

--- a/scripts/ollama-lru.sh
+++ b/scripts/ollama-lru.sh
@@ -1,0 +1,312 @@
+#!/usr/bin/env bash
+# ABOUTME: LRU-based Ollama model pruning with profile-aware protection (Story 08.1-004)
+# ABOUTME: Reports stale models, prompts for removal, or auto-prunes in --auto mode
+
+set -euo pipefail
+
+# =============================================================================
+# CONFIGURATION
+# =============================================================================
+
+# Last-use is derived (in order of preference) from:
+#   1. Ollama server log (parses "model=<name>" request lines)
+#   2. Manifest file mtime (represents pull/refresh time — floor only)
+OLLAMA_LOG="${OLLAMA_LOG:-/tmp/ollama-serve.log}"
+OLLAMA_MANIFESTS="${HOME}/.ollama/models/manifests/registry.ollama.ai/library"
+
+# Default retention window (can be overridden per invocation)
+DEFAULT_THRESHOLD_DAYS=30
+
+# Profile-expected models (mirror flake.nix ollamaModels.* and health-api.py).
+# These are NEVER auto-removed in --auto mode, but can be manually selected
+# via --prune.  Keep in sync with flake.nix.
+PROFILE_STANDARD=(ministral-3 nomic-embed-text)
+PROFILE_POWER=(gemma4 nomic-embed-text)
+PROFILE_AI_ASSISTANT=(nomic-embed-text)
+
+# =============================================================================
+# PROFILE DETECTION
+# =============================================================================
+
+detect_profile() {
+    local candidates=(
+        "${HOME}/.config/nix-install/user-config.nix"
+        "${HOME}/nix-install/user-config.nix"
+        "${HOME}/Documents/nix-install/user-config.nix"
+    )
+    for config in "${candidates[@]}"; do
+        if [[ -f "${config}" ]]; then
+            local p
+            p=$(grep -E '^\s*installProfile\s*=' "${config}" 2>/dev/null \
+                | sed -E 's/.*"([^"]+)".*/\1/' || true)
+            if [[ "${p}" == "power" || "${p}" == "standard" || "${p}" == "ai-assistant" ]]; then
+                echo "${p}"
+                return 0
+            fi
+        fi
+    done
+    echo "standard"  # conservative fallback
+}
+
+# Return protected model name prefixes for the detected profile.
+profile_protected_prefixes() {
+    local profile="$1"
+    case "${profile}" in
+        power)        printf '%s\n' "${PROFILE_POWER[@]}" ;;
+        ai-assistant) printf '%s\n' "${PROFILE_AI_ASSISTANT[@]}" ;;
+        *)            printf '%s\n' "${PROFILE_STANDARD[@]}" ;;
+    esac
+}
+
+# Return 0 if the given model tag starts with any profile-protected prefix.
+is_protected() {
+    local tag="$1"
+    local profile="$2"
+    local base="${tag%%:*}"   # strip ":14b" etc. to compare on family name
+    while read -r prefix; do
+        [[ "${base}" == "${prefix}" ]] && return 0
+    done < <(profile_protected_prefixes "${profile}")
+    return 1
+}
+
+# =============================================================================
+# LAST-USE DETECTION
+# =============================================================================
+
+# Print the most recent epoch timestamp a model appears in the server log,
+# or "0" if no entry is found.
+# Ollama server logs include lines like: ... model=gemma4:26b ...
+last_use_from_log() {
+    local tag="$1"
+    if [[ ! -f "${OLLAMA_LOG}" ]]; then
+        echo 0
+        return
+    fi
+    # Grep lines mentioning this exact tag; keep newest; extract the "time=...T..." stamp
+    local line
+    line=$(grep -F "model=${tag}" "${OLLAMA_LOG}" 2>/dev/null | tail -1 || true)
+    if [[ -z "${line}" ]]; then
+        echo 0
+        return
+    fi
+    # Ollama server logs time as "time=2026-04-21T17:00:00.000Z level=INFO ..."
+    local ts_iso
+    ts_iso=$(echo "${line}" | grep -oE 'time="?[0-9T:.-]+Z?' | head -1 | sed -E 's/^time="?//' || true)
+    if [[ -z "${ts_iso}" ]]; then
+        echo 0
+        return
+    fi
+    # Convert ISO-8601 → epoch on macOS (requires -j and a matching format)
+    local epoch
+    epoch=$(date -ju -f "%Y-%m-%dT%H:%M:%S" "${ts_iso%.*}" "+%s" 2>/dev/null || echo 0)
+    echo "${epoch}"
+}
+
+# Fall back to manifest mtime (covers the case of zero log entries — model
+# pulled but never used). Represents pull time, which is a conservative floor
+# for "last known activity".
+last_use_from_manifest() {
+    local tag="$1"
+    local model="${tag%%:*}"
+    local ver="${tag##*:}"
+    [[ "${ver}" == "${model}" ]] && ver="latest"
+    local path="${OLLAMA_MANIFESTS}/${model}/${ver}"
+    if [[ -f "${path}" ]]; then
+        stat -f '%m' "${path}" 2>/dev/null || echo 0
+    else
+        echo 0
+    fi
+}
+
+# Best-guess last-use epoch for a model tag.
+model_last_use_epoch() {
+    local tag="$1"
+    local from_log from_manifest
+    from_log=$(last_use_from_log "${tag}")
+    from_manifest=$(last_use_from_manifest "${tag}")
+    if [[ "${from_log}" -gt "${from_manifest}" ]]; then
+        echo "${from_log}"
+    else
+        echo "${from_manifest}"
+    fi
+}
+
+# =============================================================================
+# MODEL ENUMERATION
+# =============================================================================
+
+# Parse `ollama list` output to yield "tag<TAB>size" lines.
+list_models() {
+    if ! command -v ollama &>/dev/null; then
+        echo "ollama: command not found" >&2
+        return 1
+    fi
+    ollama list 2>/dev/null | awk 'NR>1 && $1 != "" { print $1 "\t" $3 $4 }'
+}
+
+# =============================================================================
+# REPORTING
+# =============================================================================
+
+now_epoch() { date '+%s'; }
+
+# Print a pretty-printed analysis table.
+# Format: tag  size  last-used  days-idle  protected?
+analyze() {
+    local profile; profile=$(detect_profile)
+    local now; now=$(now_epoch)
+
+    printf '%-30s %8s %12s %10s %s\n' "MODEL" "SIZE" "LAST USE" "DAYS IDLE" "PROTECTED"
+    printf '%s\n' "---------------------------------------------------------------------------------"
+
+    while IFS=$'\t' read -r tag size; do
+        [[ -z "${tag}" ]] && continue
+        local epoch; epoch=$(model_last_use_epoch "${tag}")
+        local days_idle="-"
+        local last_str="never"
+        if [[ "${epoch}" -gt 0 ]]; then
+            days_idle=$(( (now - epoch) / 86400 ))
+            last_str=$(date -r "${epoch}" '+%Y-%m-%d')
+        fi
+        local prot="no"
+        is_protected "${tag}" "${profile}" && prot="yes"
+        printf '%-30s %8s %12s %10s %s\n' "${tag}" "${size}" "${last_str}" "${days_idle}" "${prot}"
+    done < <(list_models)
+
+    echo ""
+    echo "Profile: ${profile} — models matching protected prefixes are never auto-pruned."
+}
+
+# Return stale model tags (days-idle > threshold) as newline-separated list.
+stale_tags() {
+    local threshold_days="$1"
+    local now; now=$(now_epoch)
+    local threshold_sec=$(( threshold_days * 86400 ))
+
+    while IFS=$'\t' read -r tag size; do
+        [[ -z "${tag}" ]] && continue
+        local epoch; epoch=$(model_last_use_epoch "${tag}")
+        # If we have no signal at all, don't flag (let user decide)
+        [[ "${epoch}" -eq 0 ]] && continue
+        local idle=$(( now - epoch ))
+        if [[ "${idle}" -gt "${threshold_sec}" ]]; then
+            echo "${tag}"
+        fi
+    done < <(list_models)
+}
+
+# Interactive prune — ask y/N per stale model.
+prune_interactive() {
+    local threshold_days="$1"
+    local profile; profile=$(detect_profile)
+    local tags
+    tags=$(stale_tags "${threshold_days}")
+    if [[ -z "${tags}" ]]; then
+        echo "No models idle for >${threshold_days}d."
+        return 0
+    fi
+
+    echo "Stale models (idle >${threshold_days}d, profile=${profile}):"
+    echo ""
+    while IFS= read -r tag; do
+        local prot="no"; is_protected "${tag}" "${profile}" && prot="yes (profile-expected)"
+        local epoch; epoch=$(model_last_use_epoch "${tag}")
+        local last_str="never"; [[ "${epoch}" -gt 0 ]] && last_str=$(date -r "${epoch}" '+%Y-%m-%d')
+        printf '  %s  (last use: %s, protected: %s)\n' "${tag}" "${last_str}" "${prot}"
+    done <<< "${tags}"
+    echo ""
+
+    while IFS= read -r tag; do
+        read -r -p "Remove ${tag}? [y/N] " reply </dev/tty || reply=""
+        case "${reply}" in
+            [yY]|[yY][eE][sS])
+                if ollama rm "${tag}"; then
+                    echo "✓ Removed: ${tag}"
+                else
+                    echo "✗ Failed to remove: ${tag}" >&2
+                fi
+                ;;
+            *)
+                echo "  skipped: ${tag}"
+                ;;
+        esac
+    done <<< "${tags}"
+}
+
+# Non-interactive prune — used by the LaunchAgent.
+# Never touches profile-protected models.
+prune_auto() {
+    local threshold_days="$1"
+    local profile; profile=$(detect_profile)
+    local removed=0
+    while IFS= read -r tag; do
+        [[ -z "${tag}" ]] && continue
+        if is_protected "${tag}" "${profile}"; then
+            echo "⊘ Protected (profile=${profile}): ${tag}"
+            continue
+        fi
+        if ollama rm "${tag}" 2>&1; then
+            echo "✓ Removed: ${tag}"
+            removed=$((removed + 1))
+        else
+            echo "✗ Failed to remove: ${tag}" >&2
+        fi
+    done < <(stale_tags "${threshold_days}")
+    echo ""
+    echo "Summary: ${removed} model(s) removed (threshold=${threshold_days}d, profile=${profile})."
+}
+
+# =============================================================================
+# DISPATCH
+# =============================================================================
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [MODE] [options]
+
+Modes:
+  --analyze (default)   Report each model's size and days-since-use.
+  --prune               Interactive: ask y/N per stale model. Respects
+                        --threshold-days but DOES NOT auto-protect the
+                        profile-expected list (you decide).
+  --auto                Non-interactive: remove stale models. ALWAYS
+                        preserves profile-expected models. Designed for
+                        the opt-in LaunchAgent.
+
+Options:
+  --threshold-days=N    Idle-days threshold for --prune / --auto (default: ${DEFAULT_THRESHOLD_DAYS}).
+  --help, -h            This message.
+
+Env:
+  OLLAMA_LOG            Override path to the Ollama server log for
+                        last-use parsing (default: /tmp/ollama-serve.log).
+
+Profile-expected models are detected from user-config.nix and loaded
+from the hardcoded list in this script — keep in sync with flake.nix.
+EOF
+}
+
+main() {
+    local mode="analyze"
+    local threshold="${DEFAULT_THRESHOLD_DAYS}"
+
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --analyze) mode="analyze"; shift ;;
+            --prune)   mode="prune"; shift ;;
+            --auto)    mode="auto"; shift ;;
+            --threshold-days=*) threshold="${1#*=}"; shift ;;
+            --threshold-days)   threshold="${2:?}"; shift 2 ;;
+            -h|--help) usage; exit 0 ;;
+            *) echo "Unknown argument: $1" >&2; usage; exit 2 ;;
+        esac
+    done
+
+    case "${mode}" in
+        analyze) analyze ;;
+        prune)   prune_interactive "${threshold}" ;;
+        auto)    prune_auto "${threshold}" ;;
+    esac
+}
+
+main "$@"

--- a/user-config.template.nix
+++ b/user-config.template.nix
@@ -33,4 +33,12 @@
   # Defaults: power "5m", standard "2m", ai-assistant "30s".
   # Uncomment to override — format matches Go duration strings.
   # ollamaKeepAlive = "10m";
+
+  # Ollama LRU pruning (Story 08.1-004) — opt-in
+  # When true, runs ollama-lru.sh --auto monthly (1st @ 05:00) to remove
+  # models idle >threshold days. Profile-expected models are ALWAYS
+  # preserved (see flake.nix ollamaModels.*). Manual control via
+  # `ollama-lru` alias (--analyze / --prune / --auto).
+  # enableOllamaLRU = true;
+  # ollamaLRUThresholdDays = 60;  # default 60
 }


### PR DESCRIPTION
## Summary
Gives FX visibility and control over stale Ollama models with three modes: an analysis report, an interactive pruner, and an opt-in auto-mode behind a LaunchAgent. Profile-expected models from `flake.nix` are always protected in `--auto`.

Example on the Power profile right now:
```
$ ollama-lru
MODEL                             SIZE     LAST USE  DAYS IDLE PROTECTED
---------------------------------------------------------------------------------
gemma4:26b                          17GB   2026-04-21          0 yes
gemma4:e4b                         9.6GB   2026-04-14          7 yes
nomic-embed-text:latest             274MB  2026-02-20         60 yes
```

## Architecture
- Primary last-use signal: `/tmp/ollama-serve.log` `model=<tag>` API request lines (LaunchAgent stdout)
- Fallback: manifest file mtime (represents pull time — conservative floor)
- Profile detection: reads `user-config.nix` `installProfile`; falls back to `standard`
- Protection list hardcoded to match `flake.nix ollamaModels.*` and `health-api.py OLLAMA_MODELS` (comment discipline — all three in sync)

## Opt-in LaunchAgent
The agent is added to `launchd.user.agents` only when `userConfig.enableOllamaLRU = true` (via `lib.mkIf`). Default: absent, zero steady-state cost. Users opt in via:
```nix
# user-config.nix
enableOllamaLRU = true;
ollamaLRUThresholdDays = 60;   # default 60
```
Schedule: 1st of each month at 05:00.

## Test plan
- [ ] `ollama-lru` (no args) prints the analysis table with correct size/days-idle for each installed model
- [ ] `ollama-lru --prune` prompts per stale model (threshold 30d by default); `n` skips, `y` removes
- [ ] `ollama-lru --auto --threshold-days=7` removes only unprotected models older than 7d, logs protected ones as `⊘ Protected`
- [ ] Set `enableOllamaLRU = true` in `user-config.nix`, rebuild → `launchctl list | grep ollama-lru` shows loaded
- [ ] Keep flag false (default) → `launchctl list | grep ollama-lru` returns nothing
- [ ] `ollama-lru --help` works; bad args exit 2
- [ ] `bash -n scripts/ollama-lru.sh` passes (verified)
- [ ] `nix-instantiate --parse darwin/maintenance.nix` passes (verified)

## Risk
Low — default is report-only, auto-mode gated by opt-in flag AND profile-expected protection. Worst case: user manually `--prune`s a protected model (it's their decision — script warns but allows).

Implements Story 08.1-004, closes #239.

🤖 Generated with [Claude Code](https://claude.com/claude-code)