### PR TITLE
fix(disk-cleanup): Huggingface prune by mtime (atime is unreliable on macOS)

### DIFF
--- a/scripts/disk-cleanup.sh
+++ b/scripts/disk-cleanup.sh
@@ -224,9 +224,11 @@ cleanup_nodegyp() {
 
 cleanup_huggingface() {
     # Prunes model blobs and dataset snapshots older than the retention window.
-    # HF re-downloads on next use, so this only costs bandwidth, not data.
-    # APFS often defaults to noatime — atime may equal mtime; we accept the
-    # approximation. Override windows with HF_RETENTION_DAYS / HF_DATASETS_RETENTION_DAYS.
+    # HF blobs are content-addressed and immutable, so mtime = download time —
+    # a reliable "age" signal even on macOS where atime gets bumped by any
+    # Python process importing transformers. Re-download on next use is pure
+    # bandwidth, no data loss.
+    # Override windows with HF_RETENTION_DAYS / HF_DATASETS_RETENTION_DAYS.
     print_header "Cleaning Huggingface Cache"
     local cache_dir="${HOME}/.cache/huggingface"
     if [[ ! -d "${cache_dir}" ]]; then
@@ -240,8 +242,8 @@ cleanup_huggingface() {
 
     local blobs_count=0
     if [[ -d "${cache_dir}/hub" ]]; then
-        blobs_count=$(find "${cache_dir}/hub" -path "*/blobs/*" -type f -atime "+${retention}" 2>/dev/null | wc -l | tr -d ' ')
-        find "${cache_dir}/hub" -path "*/blobs/*" -type f -atime "+${retention}" -delete 2>/dev/null || true
+        blobs_count=$(find "${cache_dir}/hub" -path "*/blobs/*" -type f -mtime "+${retention}" 2>/dev/null | wc -l | tr -d ' ')
+        find "${cache_dir}/hub" -path "*/blobs/*" -type f -mtime "+${retention}" -delete 2>/dev/null || true
     fi
 
     local datasets_count=0


### PR DESCRIPTION
## Problem
The atime-based HF pruner landed in #237 silently does nothing on macOS. Any Python process importing `transformers`/`diffusers` bumps atime on every cache blob (via the library's cache-freshness checks), so `find -atime +60` matches zero files. FX reproduced on Power profile: 13 GB HF cache survived a manual `disk-cleanup` run with no blobs touched.

Diagnostic one-liner that confirms:
```bash
echo "By atime >60d: $(find ~/.cache/huggingface/hub -path '*/blobs/*' -type f -atime +60 2>/dev/null | wc -l) blobs"
echo "By mtime >60d: $(find ~/.cache/huggingface/hub -path '*/blobs/*' -type f -mtime +60 2>/dev/null | wc -l) blobs"
```

## Fix
Switch from `atime` to `mtime`. Since HF blobs are content-addressed and immutable, `mtime == download time` — exactly the "age" signal we want, independent of atime policy. Re-download on next use is pure bandwidth (no data loss), which is the trade-off #237 already accepted in principle.

## Changes
- `scripts/disk-cleanup.sh::cleanup_huggingface()`:
  - `-atime +N` → `-mtime +N` on the two `find` invocations over `hub/*/blobs/*`
  - Comment updated: drop the "APFS noatime" hedge; state mtime-based intent plainly
- Datasets already used mtime — unchanged.

## Test plan
- [ ] `disk-cleanup --analyze` on Power profile shows HF cache size as before
- [ ] `disk-cleanup` now reports `Huggingface: N blobs + M datasets pruned`
- [ ] HF cache shrinks substantially (expected ~10 GB reclaimed on FX's Power profile)
- [ ] Next `transformers` script import re-downloads one blob, proves re-fetch works
- [ ] `bash -n scripts/disk-cleanup.sh` passes (verified)

## Risk
Low — the new behavior is deterministic and matches the story's original intent. Worst case: a blob downloaded 61 days ago but actively used gets re-downloaded on next import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)