### PR TITLE
feat(nix-gc): system-level GC LaunchDaemon (#236)

### DIFF
--- a/darwin/maintenance-system.nix
+++ b/darwin/maintenance-system.nix
@@ -1,0 +1,88 @@
+# ABOUTME: Root-level LaunchDaemon for weekly system-profile garbage collection (Story 08.1-001)
+# ABOUTME: Prunes /nix/var/nix/profiles/system-*-link generations that user-level nix-gc cannot touch
+{
+  config,
+  pkgs,
+  lib,
+  userConfig,
+  ...
+}: {
+  # =============================================================================
+  # SYSTEM-LEVEL GARBAGE COLLECTION (Story 08.1-001)
+  # =============================================================================
+  # The existing user-level nix-gc LaunchAgent (darwin/maintenance.nix) runs as
+  # $USER and prunes per-user generations only. System profile generations
+  # (/nix/var/nix/profiles/system-*-link) are root-owned and accumulate unbounded
+  # until this runs — 175 generations observed on a Power-profile machine before
+  # this daemon existed.
+  #
+  # LaunchDaemon (not LaunchAgent) — needs root to touch the system profile.
+  # First launchd.daemons.* in this repo; future root-scheduled work should
+  # live alongside this module.
+  #
+  # Schedule: Sunday 04:00 — between the daily nix-gc (03:00) and
+  # nix-optimize (03:30). Running later means weekly-digest (Sunday 08:00)
+  # still sees the result in the same report cycle.
+  #
+  # Safety: `nix-collect-garbage` always preserves the currently-booted
+  # system generation, so rollback capability is preserved (just to a
+  # narrower retention window).
+
+  launchd.daemons.nix-gc-system = {
+    serviceConfig = {
+      Label = "org.nixos.nix-gc-system";
+      ProgramArguments = [
+        "/bin/bash" "-c"
+        ''
+          LOG=/var/log/nix-gc-system.log
+          {
+            echo "=== System Nix GC $(date '+%Y-%m-%d %H:%M:%S') ==="
+
+            # Capture the generation count + store size before pruning so the
+            # log shows what was reclaimed.
+            before_gens=$(ls -1 /nix/var/nix/profiles/system-*-link 2>/dev/null | wc -l | tr -d ' ')
+            before_size=$(du -sh /nix/store 2>/dev/null | cut -f1)
+            echo "Before: $before_gens system generations, /nix/store = $before_size"
+
+            if /run/current-system/sw/bin/nix-collect-garbage --delete-older-than 30d; then
+              after_gens=$(ls -1 /nix/var/nix/profiles/system-*-link 2>/dev/null | wc -l | tr -d ' ')
+              after_size=$(du -sh /nix/store 2>/dev/null | cut -f1)
+              echo "After:  $after_gens system generations, /nix/store = $after_size"
+              echo "✓ System GC completed"
+            else
+              echo "✗ System GC failed with exit code $?"
+              exit 1
+            fi
+
+            echo "---"
+          } >> "$LOG" 2>&1
+        ''
+      ];
+
+      # Weekly: Sunday 04:00
+      StartCalendarInterval = [
+        { Weekday = 0; Hour = 4; Minute = 0; }
+      ];
+
+      # Daemon runs as root (required to prune system-*-link).
+      # No need to set UserName — daemons default to root. Setting explicitly
+      # for clarity.
+      UserName = "root";
+      GroupName = "wheel";
+
+      # Logs live in /var/log (preserved across reboots, unlike /tmp).
+      # Only root-writable, which is fine — this daemon runs as root.
+      StandardOutPath = "/var/log/nix-gc-system.log";
+      StandardErrorPath = "/var/log/nix-gc-system.err";
+
+      # Sane, minimal PATH for a root cron-like job. /run/current-system/sw/bin
+      # is the primary path; the rest are fallbacks for coreutils.
+      EnvironmentVariables = {
+        PATH = "/run/current-system/sw/bin:/usr/bin:/bin:/usr/sbin:/sbin";
+      };
+
+      RunAtLoad = false;
+      Umask = 77;  # 0077 — logs owner-readable only
+    };
+  };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -236,6 +236,11 @@
       # Automated garbage collection and store optimization
       ./darwin/maintenance.nix
 
+      # System-level Nix GC LaunchDaemon (Epic-08 Story 08.1-001)
+      # Root-owned weekly prune of system profile generations — the user-level
+      # nix-gc agent above cannot touch /nix/var/nix/profiles/system-*-link
+      ./darwin/maintenance-system.nix
+
       # Health API Server (HTTP JSON endpoint on port 7780)
       # Accessible via Tailscale for remote health monitoring
       ./darwin/health-api.nix


### PR DESCRIPTION
## Summary
First `launchd.daemons.*` in the repo. Prunes root-owned `/nix/var/nix/profiles/system-*-link` generations that the existing user-level `nix-gc` agent cannot reach. On Power profile baseline the count was at **175** — well past the health-check warning threshold of 50.

## Behavior
- **Schedule**: Sunday 04:00, between daily `nix-gc` (03:00) and weekly-digest (Sunday 08:00)
- **Command**: `nix-collect-garbage --delete-older-than 30d` — same retention as the user agent, keeps rollback capability intact
- **Safety**: nix-collect-garbage always preserves the currently-booted generation; worst case the rollback window narrows from months to 30d
- **Logs**: `/var/log/nix-gc-system.log` (preserved across reboots, unlike `/tmp`). Before/after snapshot of generation count + `/nix/store` size so the weekly digest reflects real reclaim
- **Permissions**: runs as `root:wheel`, `Umask=77` (logs owner-readable only)
- **PATH**: minimal, `/run/current-system/sw/bin` primary

## Scope kept minimal
No email-on-failure yet. `send-notification.sh` lives in `~/.local/bin` (user-owned); invoking it from a root daemon would need `sudo -u $user` + environment setup. Weekly digest already parses the log file — a separate follow-up can wire email if we hit a silent failure in practice.

## Files
- **New**: `darwin/maintenance-system.nix` — the LaunchDaemon definition
- **Wired**: `flake.nix` `commonModules` — added alongside `maintenance.nix`

## Test plan
- [ ] `darwin-rebuild switch` loads the daemon (requires sudo — normal for rebuild)
- [ ] `sudo launchctl list | rg nix-gc-system` shows loaded
- [ ] Manual fire: `sudo launchctl start org.nixos.nix-gc-system` → log shows "Before: N system generations ... After: <N" within seconds
- [ ] System generation count drops from 175 → <20 on first real run
- [ ] `sudo launchctl print system/org.nixos.nix-gc-system` shows `state = running` during execution and `state = not running` after (daemons are one-shots unless keep-alive)
- [ ] `darwin-rebuild --rollback` — rollback still works after (proves we didn't delete active generation)
- [ ] `nix flake check --no-build` passes (verified)
- [ ] `nix-instantiate --parse darwin/maintenance-system.nix` passes (verified)

## Risk
Medium — first root-level LaunchDaemon in the repo. Mitigations:
- Same retention (30d) as user-level agent, already proven in production
- nix-collect-garbage preserves current generation (kernel-level invariant)
- Weekly cadence (not daily), so a bad run has a full week to be caught before the next
- Log evidence is persistent in /var/log, easy to audit

Implements Story 08.1-001, closes #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)