### PR TITLE
feat(ollama): memory-pressure auto-unload guard (#245)

### DIFF
--- a/darwin/maintenance.nix
+++ b/darwin/maintenance.nix
@@ -357,6 +357,53 @@ in {
     };
 
     # =========================================================================
+    # OLLAMA MEMORY-PRESSURE GUARD (Story 08.2-002)
+    # =========================================================================
+    # Polls every 60s and unloads all Ollama models when swap usage crosses
+    # the configured threshold. Restores RAM to other workloads without the
+    # user having to notice + intervene.
+    #
+    # Complements ollama-serve tuning (Story 08.2-001) which shortens
+    # keep-alive by default — this catches the case where a user keeps
+    # requests coming and the keep-alive timer never expires.
+    #
+    # Uses StartInterval (not StartCalendarInterval) for periodic sampling.
+    # Defined directly because the mkScheduledAgent helper doesn't cover
+    # this shape.
+    #
+    # Tunable via env on the LaunchAgent (rebuild after changes):
+    #   OLLAMA_UNLOAD_ON_PRESSURE  off|warn|critical   (default warn)
+    #   SWAP_WARN_GB               default 2
+    #   SWAP_CRITICAL_GB           default 5
+    ollama-pressure-guard = {
+      serviceConfig = {
+        Label = "org.nixos.ollama-pressure-guard";
+        ProgramArguments = [
+          "/bin/bash" "-c"
+          ''
+            SCRIPT="${scriptsDir}/ollama-pressure-guard.sh"
+            if [[ -x "$SCRIPT" ]]; then
+              "$SCRIPT"
+            else
+              echo "ollama-pressure-guard script not found: $SCRIPT" >> /tmp/ollama-pressure-guard.err
+              exit 1
+            fi
+          ''
+        ];
+        StartInterval = 60;  # Every minute
+        StandardOutPath = "/tmp/ollama-pressure-guard.log";
+        StandardErrorPath = "/tmp/ollama-pressure-guard.err";
+        EnvironmentVariables = {
+          PATH = "/opt/homebrew/bin:${agentPath}";
+          HOME = agentHome;
+          OLLAMA_UNLOAD_ON_PRESSURE = userConfig.ollamaUnloadOnPressure or "warn";
+        };
+        RunAtLoad = false;
+        Umask = 77;
+      };
+    };
+
+    # =========================================================================
     # OLLAMA SERVER (Network-accessible via Tailscale)
     # =========================================================================
     # Starts Ollama server at login bound to all interfaces (0.0.0.0)

--- a/scripts/ollama-pressure-guard.sh
+++ b/scripts/ollama-pressure-guard.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# ABOUTME: Auto-unload Ollama models when macOS is under sustained memory pressure (Story 08.2-002)
+# ABOUTME: Invoked every 60s by the ollama-pressure-guard LaunchAgent (darwin/maintenance.nix)
+#
+# Problem: default Ollama behavior pins a loaded model in RAM for its full
+# keep-alive window. On a 48 GB machine running gemma4:26b (17 GB resident)
+# plus a browser-heavy workload, this tips macOS into swap thrash — the 3 GB
+# swap + 11 GB compressor baseline seen at Epic-08 baseline.
+#
+# This script probes swap usage every minute and, when it exceeds the
+# configured threshold, unloads every loaded Ollama model via the API
+# (keep_alive=0). Ollama re-loads on the next request — cold-load penalty
+# is cheap compared to the cost of swap-thrashing other workloads.
+#
+# Configuration (env vars):
+#   OLLAMA_UNLOAD_ON_PRESSURE  off|warn|critical   (default: warn)
+#                              off      — never unload
+#                              warn     — unload when swap > SWAP_WARN_GB
+#                              critical — unload only at SWAP_CRITICAL_GB
+#   SWAP_WARN_GB               default 2   (matches health-api.py SWAP_WARNING_GB)
+#   SWAP_CRITICAL_GB           default 5
+#
+# Logs: /tmp/ollama-pressure.log — timestamp, swap_gb, action taken
+
+set -euo pipefail
+
+LOG=/tmp/ollama-pressure.log
+MODE="${OLLAMA_UNLOAD_ON_PRESSURE:-warn}"
+SWAP_WARN_GB="${SWAP_WARN_GB:-2}"
+SWAP_CRITICAL_GB="${SWAP_CRITICAL_GB:-5}"
+OLLAMA_URL="${OLLAMA_URL:-http://localhost:11434}"
+
+log() {
+    printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$*" >> "$LOG"
+}
+
+# Quick exit if operator disabled the guard
+if [[ "$MODE" == "off" ]]; then
+    exit 0
+fi
+
+# Current swap usage in whole GB (integer floor).
+# sysctl output: "total = 4096.00M  used = 850.75M  free = 3245.25M  (encrypted)"
+swap_used_mb=$(sysctl -n vm.swapusage 2>/dev/null | sed -nE 's/.*used = ([0-9]+)\.[0-9]+M.*/\1/p' || echo 0)
+swap_used_gb=$(( swap_used_mb / 1024 ))
+
+# Pick the active threshold based on mode.
+threshold_gb=$SWAP_WARN_GB
+[[ "$MODE" == "critical" ]] && threshold_gb=$SWAP_CRITICAL_GB
+
+# Under the threshold → no action. Don't spam the log on quiet ticks.
+if (( swap_used_gb < threshold_gb )); then
+    exit 0
+fi
+
+# Over threshold — check whether Ollama is even responding.
+if ! curl -sf --max-time 2 "${OLLAMA_URL}/api/version" >/dev/null 2>&1; then
+    log "pressure=${swap_used_gb}GB (mode=${MODE}, threshold=${threshold_gb}GB) — Ollama not responding, skipping"
+    exit 0
+fi
+
+# Enumerate loaded models from `ollama ps`. First column is NAME.
+# Skip header line (NR>1) and empty lines.
+loaded=$(ollama ps 2>/dev/null | awk 'NR>1 && NF>0 {print $1}' || true)
+
+if [[ -z "$loaded" ]]; then
+    log "pressure=${swap_used_gb}GB (mode=${MODE}, threshold=${threshold_gb}GB) — no models loaded, skipping"
+    exit 0
+fi
+
+# Unload every loaded model. keep_alive=0 tells Ollama to release immediately.
+# We accept the small risk of aborting an in-flight request; a 60s tick
+# interval makes this rare, and the alternative (continued swap thrash) is
+# worse for overall system responsiveness.
+unloaded=""
+failed=""
+while IFS= read -r model; do
+    if curl -sf --max-time 5 "${OLLAMA_URL}/api/generate" \
+         -d "{\"model\":\"${model}\",\"keep_alive\":0}" >/dev/null 2>&1; then
+        unloaded="${unloaded}${unloaded:+,}${model}"
+    else
+        failed="${failed}${failed:+,}${model}"
+    fi
+done <<< "$loaded"
+
+log "pressure=${swap_used_gb}GB (mode=${MODE}, threshold=${threshold_gb}GB) unloaded=[${unloaded:-none}]${failed:+ failed=[${failed}]}"

--- a/user-config.template.nix
+++ b/user-config.template.nix
@@ -41,4 +41,10 @@
   # `ollama-lru` alias (--analyze / --prune / --auto).
   # enableOllamaLRU = true;
   # ollamaLRUThresholdDays = 60;  # default 60
+
+  # Ollama memory-pressure guard (Story 08.2-002)
+  # Default: "warn" — unload loaded models when swap usage > 2 GB.
+  # "critical" — only unload when swap > 5 GB (less aggressive).
+  # "off" — disable the guard entirely.
+  # ollamaUnloadOnPressure = "warn";
 }


### PR DESCRIPTION
## Summary
Catches the case #264's keep-alive tuning can't reach: a user keeps requests coming and the idle timer never expires, producing sustained swap pressure. Every 60s, the new `ollama-pressure-guard` LaunchAgent samples `sysctl vm.swapusage` and unloads loaded Ollama models when swap crosses the configured threshold.

Aligned with #265: the warn-mode threshold (2 GB swap) is the same signal that already triggers `/metrics status_flags.memory_swap`, so the guard fires at the exact moment the user sees the alert.

## Modes
```
ollamaUnloadOnPressure = "warn"      # default — unload at swap > 2 GB
ollamaUnloadOnPressure = "critical"  # less aggressive — swap > 5 GB
ollamaUnloadOnPressure = "off"       # disable entirely
```

## Behavior
1. `sysctl vm.swapusage` → integer GB used
2. Under threshold → silent no-op (don't spam log)
3. Over threshold → probe `GET /api/version` (skip if Ollama down)
4. Enumerate loaded models (`ollama ps` col 1)
5. Unload each via `POST /api/generate` with `keep_alive=0`
6. Log to `/tmp/ollama-pressure.log` with swap GB + action

Example log line:
```
2026-04-21T21:04:00 pressure=3GB (mode=warn, threshold=2GB) unloaded=[gemma4:26b]
```

## Trade-offs
- **In-flight request may abort** if the unload lands mid-request. Rare given 60s tick interval; acceptable because the alternative is continued swap thrash hurting all workloads. Users who disagree can set `ollamaUnloadOnPressure = "critical"` or `"off"`.
- **No active-request guard in V1**. Future enhancement: check `ollama-serve.log` tail for POST /api/generate within last 10s and defer. Kept out of scope to ship the P0 memory win now.

## Files
- **New**: `scripts/ollama-pressure-guard.sh`
- **Modified**: `darwin/maintenance.nix` — new StartInterval=60 LaunchAgent
- **Modified**: `user-config.template.nix` — commented `ollamaUnloadOnPressure` override

## Test plan
- [ ] After rebuild: `launchctl list | rg ollama-pressure-guard` shows loaded
- [ ] Manual fire under low pressure: `launchctl start org.nixos.ollama-pressure-guard` → no log line (quiet when OK)
- [ ] Induce swap: `stress-ng --vm 4 --vm-bytes 12G` for 90s with gemma4:26b loaded → within 1 minute, `/tmp/ollama-pressure.log` shows unload line and `ollama ps` is empty
- [ ] Stop stressor → swap drains → `ollama run gemma4:26b "hi"` still works (re-load)
- [ ] Set `ollamaUnloadOnPressure = "off"` → rebuild → same stress test, guard stays silent
- [ ] `bash -n scripts/ollama-pressure-guard.sh` passes (verified)
- [ ] `nix-instantiate --parse darwin/maintenance.nix` passes (verified)

## Risk
Medium — runtime-intrusive (can abort in-flight requests). Mitigations: opt-out env var, conservative threshold matching the existing /metrics warn level, 60s tick minimizes collision window.

Implements Story 08.2-002, closes #245.

🤖 Generated with [Claude Code](https://claude.com/claude-code)