### PR TITLE
fix(activation): sync ollama-pressure-guard.sh + ollama-lru.sh to ~/.local/bin

### DIFF
--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -226,6 +226,9 @@
           "health-api.py"
           "health-check.sh"
           "claude-cleanup.sh"
+          # Epic-08: invoked by always-on / opt-in LaunchAgents (darwin/maintenance.nix)
+          "ollama-pressure-guard.sh"  # 60s guard; Story 08.2-002
+          "ollama-lru.sh"             # monthly opt-in prune; Story 08.1-004
         )
 
         for script in "''${COMMON_SCRIPTS[@]}"; do


### PR DESCRIPTION
## Problem
LaunchAgents from Wave 2 (#268 ollama-lru) and Wave 3 (#271 ollama-pressure-guard) reference `\${scriptsDir}/...` → `~/.local/bin/`. The activation block in `darwin/configuration.nix` hardcodes the script sync list; I added the LaunchAgents but forgot to extend it.

FX observable right now after rebuild:
```
$ cat /tmp/ollama-pressure-guard.err
ollama-pressure-guard script not found: /Users/fxmartin/.local/bin/ollama-pressure-guard.sh
ollama-pressure-guard script not found: /Users/fxmartin/.local/bin/ollama-pressure-guard.sh
...
```
Agent exits 1 every 60s. `ollama-lru` has the same latent bug, but only triggers when `enableOllamaLRU = true`.

## Fix
Add both to `COMMON_SCRIPTS` in `darwin/configuration.nix` (every profile, since the pressure guard loads unconditionally and the LRU opt-in works on any profile).

`audit-launchagents.sh` is intentionally excluded — invoked only via the `audit-launchagents` zsh alias using the repo path, not `~/.local/bin`.

## Test plan
- [ ] `darwin-rebuild switch` — activation log shows `✓ Synced ollama-pressure-guard.sh` and `✓ Synced ollama-lru.sh`
- [ ] `ls ~/.local/bin/ollama-*.sh` returns both files, mode 755
- [ ] `launchctl list | rg ollama-pressure-guard` exits 0 (PID column empty after tick) — no error in `/tmp/ollama-pressure-guard.err`
- [ ] `ollama-lru` alias still works (uses repo path, unchanged)

## Risk
Trivial — 3-line addition to an existing array. No schema changes.

Fixes Wave 2/3 deployment gap (no story number — maintenance fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)