### PR TITLE
fix(audit): || true on pid probes so pipefail doesn't kill the script

### DIFF
--- a/scripts/audit-launchagents.sh
+++ b/scripts/audit-launchagents.sh
@@ -41,10 +41,14 @@ SYSTEM_DAEMONS=(
 )
 
 # Resolve the pid of a user-level service, or empty string if not running.
+# `|| true` — launchctl print exits non-zero for unloaded services, which
+# would kill the script under `set -euo pipefail`. Non-running is a normal
+# outcome we want to report as empty, not as an error.
 user_agent_pid() {
     local label="$1"
     launchctl print "gui/$UID/org.nixos.${label}" 2>/dev/null \
-        | awk '/^[[:space:]]*pid = / {print $3; exit}'
+        | awk '/^[[:space:]]*pid = / {print $3; exit}' \
+        || true
 }
 
 # Resolve the pid of a system-level daemon.
@@ -56,10 +60,12 @@ system_daemon_pid() {
 }
 
 # Return RSS (in KB) for a pid, or empty if the process has exited.
+# `|| true` — ps exits non-zero when the pid no longer exists (common
+# for scheduled one-shots that fire between samples).
 rss_kb() {
     local pid="$1"
     [[ -z "$pid" ]] && return 0
-    ps -o rss= -p "$pid" 2>/dev/null | awk '{print $1}'
+    ps -o rss= -p "$pid" 2>/dev/null | awk '{print $1}' || true
 }
 
 # Compute median of stdin (newline-separated integers). Empty input → empty output.


### PR DESCRIPTION
## Problem
`audit-launchagents` exits after \"Sample 1/10...\" instead of running the full 5 minutes. Root cause: `set -euo pipefail` + pipelines that legitimately return non-zero.

- `launchctl print gui/\$UID/org.nixos.<label>` exits non-zero when a service isn't loaded (normal outcome for scheduled one-shots during the audit window)
- `ps -o rss= -p <pid>` exits non-zero when the pid no longer exists

Under `pipefail`, either propagates failure to the surrounding pipeline → `set -e` kills the script on the first encounter (e.g. `nix-gc` not running, which is the first agent in the list for FX).

## Fix
Add `|| true` to `user_agent_pid()` and `rss_kb()`. The corresponding `system_daemon_pid()` already had it — this just makes the other two consistent. Comments explain why the \"failure\" is a normal reportable state.

## Test plan
- [ ] `audit-launchagents` runs to completion (~5 minutes, 10 samples)
- [ ] Output includes both always-on agents (`ollama-serve`, `health-api`, `beszel-agent` — `10/10` samples with RSS) and scheduled one-shots (`nix-gc`, `disk-cleanup`, etc. — `0/10` with \"not running\" note)
- [ ] No premature exit, no error output

## Risk
Trivial — 2 bash lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)