### PR TITLE
feat(health-api): top-5 CPU processes in /metrics (#257)

### DIFF
--- a/scripts/health-api.py
+++ b/scripts/health-api.py
@@ -334,6 +334,38 @@ def _stale_metrics_fallback(error_detail: str) -> dict:
     return {"status": "error", "detail": error_detail}
 
 
+def _top_cpu_processes(n: int = 5) -> list[dict]:
+    """Return the top-N CPU-consuming processes as [{pid, cpu_percent, name}, ...].
+
+    Uses BSD ps (macOS) with whitespace-stripped columns, sorts numerically on
+    pcpu desc. Skips the health-api server itself to avoid self-referential
+    noise in the SketchyBar vitals popup. Truncates long process names to 40
+    chars for compact rendering.
+    """
+    # Ask for n+1 rows to have headroom when filtering out our own process.
+    out = run(f"ps -Ao pid=,pcpu=,comm= | sort -k2 -nr | head -{n + 2}")
+    results: list[dict] = []
+    for line in out.splitlines():
+        parts = line.split(None, 2)
+        if len(parts) < 3:
+            continue
+        pid_s, pct_s, name = parts
+        # Filter the health-api python process; it appears under its script path.
+        if name.endswith("health-api.py"):
+            continue
+        try:
+            results.append({
+                "pid": int(pid_s),
+                "cpu_percent": float(pct_s),
+                "name": name[:40],
+            })
+        except ValueError:
+            continue
+        if len(results) >= n:
+            break
+    return results
+
+
 def _thermal_state_from_temps(cpu_temp: float, gpu_temp: float) -> str:
     """Synthesize a thermal state string from CPU/GPU temperatures.
 
@@ -480,6 +512,11 @@ def get_system_metrics() -> dict:
         status_flags["memory_swap"] = "warn"
     if status_flags:
         response["status_flags"] = status_flags
+
+    # Top CPU processes — consumed by SketchyBar vitals popup (Story 08.3-005)
+    # to avoid forking `ps` inside the click handler. Cached with the rest of
+    # the metrics response (2s TTL).
+    response["processes"] = {"top_cpu": _top_cpu_processes(5)}
 
     _metrics_cache = response
     _metrics_cache_time = now


### PR DESCRIPTION
## Summary
Unblocks the upcoming SketchyBar vitals popup (#253) by exposing top-5 CPU processes directly in `/metrics`. Avoids forking `ps` inside click handlers — reuses the existing 2s metrics cache.

## New field
```json
{
  "processes": {
    "top_cpu": [
      {"pid": 1234, "cpu_percent": 45.2, "name": "ollama"},
      {"pid": 5678, "cpu_percent": 22.1, "name": "Google Chrome"},
      ...
    ]
  }
}
```

## Design
- BSD `ps -Ao pid=,pcpu=,comm=` sorted desc by pcpu
- Self-filter: skips `health-api.py` to avoid self-referential noise
- Asks for N+2 rows so self-filter doesn't leave the list short
- Truncates process names to 40 chars
- Additive field — no schema break

## Test plan
- [ ] Restart health-api: `launchctl kickstart -k gui/$UID/org.nixos.health-api`
- [ ] `curl -s localhost:7780/metrics | jq .processes.top_cpu` returns 5 entries
- [ ] `health-api.py` itself never appears in the list (self-filter works)
- [ ] Entries are sorted by `cpu_percent` descending
- [ ] p95 latency unchanged vs. previous metrics shape (same 2s cache TTL)
- [ ] `python3 -c 'import ast; ast.parse(...)'` passes (verified)

## Risk
Low — additive field behind the existing 2s cache. Already-tuned `run()` wrapper handles shell-safe subprocess; same pattern used elsewhere in the file.

Implements Story 08.4-001, closes #257.

🤖 Generated with [Claude Code](https://claude.com/claude-code)