### PR TITLE
feat(sketchybar): system.sh /metrics aggregator + event (#249)

### DIFF
--- a/config/sketchybar/plugins/system.sh
+++ b/config/sketchybar/plugins/system.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# ABOUTME: SketchyBar /metrics aggregator — single poller that fans out to all system items
+# ABOUTME: Triggers system_metrics_update event with parsed values for cpu.e/cpu.p/gpu/ane/power/temp/memory
+
+# Replaces N per-plugin top/ioreg/swift/vm_stat spawns with a single
+# HTTP fetch per tick. Runs every update_freq (see sketchybarrc — 2s
+# on AC, 10s on battery per Story 08.3-007).
+#
+# On success: triggers system_metrics_update with all parsed values as env.
+# On failure (timeout, non-200, parse error): triggers with STALE=1 so
+# consumer items can dim to grey rather than render stale numbers.
+
+METRICS_URL="${SKETCHYBAR_METRICS_URL:-http://localhost:7780/metrics}"
+
+JSON=$(curl -s --max-time 1 "$METRICS_URL" 2>/dev/null)
+if [ -z "$JSON" ]; then
+  sketchybar --trigger system_metrics_update STALE=1
+  exit 0
+fi
+
+# Parse with jq. `// 0` and `// ""` defaults guard against missing fields
+# (older health-api versions won't have ANE/power/processes yet).
+PAYLOAD=$(echo "$JSON" | jq -r '
+  [
+    "CPU_E="  + ((.cpu.e_cluster.active_percent // 0) | tostring),
+    "CPU_P="  + ((.cpu.p_cluster.active_percent // 0) | tostring),
+    "GPU="    + ((.gpu.usage_percent // 0) | tostring),
+    "GPU_MHZ=" + ((.gpu.freq_mhz // 0) | tostring),
+    "ANE_W="  + ((.power.ane_watts // 0) | tostring),
+    "WATTS="  + ((.power.total_watts // 0) | tostring),
+    "TEMP_CPU=" + ((.thermal.cpu_temp_c // 0) | tostring),
+    "TEMP_GPU=" + ((.thermal.gpu_temp_c // 0) | tostring),
+    "MEM_USED=" + ((.memory.used_gb // 0) | tostring),
+    "MEM_TOTAL=" + ((.memory.total_gb // 0) | tostring),
+    "SWAP_USED=" + ((.memory.swap_used_gb // 0) | tostring),
+    "STALE=0"
+  ] | join(" ")
+' 2>/dev/null)
+
+if [ -z "$PAYLOAD" ]; then
+  sketchybar --trigger system_metrics_update STALE=1
+  exit 0
+fi
+
+# shellcheck disable=SC2086  # intentional: $PAYLOAD is space-separated KEY=VAL pairs
+sketchybar --trigger system_metrics_update $PAYLOAD

--- a/config/sketchybar/sketchybarrc
+++ b/config/sketchybar/sketchybarrc
@@ -70,6 +70,12 @@ sketchybar --set apple \
   popup.background.shadow.drawing=on \
   popup.y_offset=5
 
+##### Custom events #####
+# Centralized /metrics aggregator — Story 08.3-001.
+# All CPU/GPU/memory/thermal/power items subscribe to this event and update
+# from parsed env vars rather than spawning their own silicon probes.
+sketchybar --add event system_metrics_update
+
 ##### Adding AeroSpace Workspace Indicators #####
 # AeroSpace manages its own workspaces on top of a single macOS Space.
 # We subscribe to the custom `aerospace_workspace_change` event, triggered by
@@ -170,6 +176,15 @@ sketchybar --add item clock right \
              popup.background.corner_radius=12 \
              popup.background.height=32 \
              popup.y_offset=5
+
+##### System metrics aggregator (Story 08.3-001) #####
+# Invisible item that polls /metrics every 2s and fans values out to all
+# subscribed items via the `system_metrics_update` event. Drawing disabled
+# so it takes no bar real estate — just drives the event loop.
+sketchybar --add item system right \
+           --set system update_freq=2 \
+             drawing=off \
+             script="$PLUGIN_DIR/system.sh"
 
 ##### Force all scripts to run the first time (never do this in a script) #####
 sketchybar --update


### PR DESCRIPTION
## Summary
Foundation for the Wave 4 SketchyBar overhaul. One `curl /metrics` per tick fans out to every system item via a new `system_metrics_update` event — replaces N independent `top`/`ioreg`/`swift`/`vm_stat` spawns.

## Architecture
```
system.sh (update_freq=2)
  ├─ curl --max-time 1 /metrics
  ├─ jq extract → KEY=VAL pairs
  └─ sketchybar --trigger system_metrics_update CPU_E=... CPU_P=... etc.
```

### Exposed env (for future subscribers)
`CPU_E`, `CPU_P` (per-cluster active %), `GPU`, `GPU_MHZ`, `ANE_W`, `WATTS`, `TEMP_CPU`, `TEMP_GPU`, `MEM_USED`, `MEM_TOTAL`, `SWAP_USED`, `STALE` (0 or 1).

### Graceful degradation
On curl timeout, non-200, or jq parse error → trigger with `STALE=1`. Subsequent items (#250–#254) will dim to grey on stale, not render misleading numbers.

## Files
- **New**: `config/sketchybar/plugins/system.sh`
- **Modified**: `config/sketchybar/sketchybarrc`:
  - Register `system_metrics_update` event
  - Add invisible `system` item (`drawing=off`) with `update_freq=2` — takes no bar real estate, just drives the event loop

No consumer items added yet — that's #250 (per-cluster CPU), first of the five bar-item stories.

## Test plan
- [ ] `sketchybar --reload` — no errors
- [ ] `sketchybar --query system` shows the new item with `drawing: off`
- [ ] `sketchybar --query events` lists `system_metrics_update`
- [ ] Manually run `bash config/sketchybar/plugins/system.sh` → no output (event fires silently), no errors
- [ ] `sh -n config/sketchybar/plugins/system.sh` passes (verified)
- [ ] health-api is up → event fires every 2s (observable via subscriber added in #250)
- [ ] Kill health-api temporarily → `STALE=1` fires instead (fallback path)

## Risk
Low — purely additive. No existing plugin is touched yet; old `cpu.sh`/`gpu.sh`/`memory.sh`/`thermal.sh` still fire on their own `update_freq`. Those get retired incrementally in #250–#252.

Implements Story 08.3-001, closes #249.

🤖 Generated with [Claude Code](https://claude.com/claude-code)