### PR TITLE
feat(telemetry): custom sensor scripts for power + silicon temps (#258)

### DIFF
--- a/scripts/beszel-sensors/README.md
+++ b/scripts/beszel-sensors/README.md
@@ -1,0 +1,39 @@
+# Custom telemetry sensors (Story 08.4-002)
+
+Small wrappers that fetch values from the local `health-api` `/metrics`
+endpoint and print a single float to stdout. Designed to be consumed by
+any time-series backend or log pipeline that can exec an external program.
+
+## Available sensors
+
+| Script | Output | Source |
+|--------|--------|--------|
+| `power.sh` | total system power in watts | `.power.total_watts` |
+| `temp.sh` | hottest silicon temp in °C | `max(.thermal.cpu_temp_c, .thermal.gpu_temp_c)` |
+| `temp_gpu.sh` | GPU temp alone | `.thermal.gpu_temp_c` |
+
+All sensors print a single line on stdout (e.g. `23.4`) and exit 0
+on success, or exit 1 with no stdout on failure. This makes them
+safe to use in pipelines that want to distinguish missing data from
+a legitimate zero reading.
+
+## Design goals
+
+- **Zero steady-state cost**: sensors are pull-based; they only run when
+  their consumer polls them.
+- **Reuse the 2s /metrics cache**: health-api already collects macmon
+  data on a 2s TTL, so frequent sensor polls (sub-second) are cheap.
+- **Silent-failure**: never print noise on error — callers can re-try
+  without filtering stderr.
+
+## Beszel integration — deferred
+
+At time of writing, the upstream `beszel-agent` doesn't expose a generic
+custom-metric plugin interface on macOS (it supports `EXTRA_FS` and
+`SYS_SENSORS` for Linux lm-sensors). When Beszel adds a program-sensor
+hook, wire the scripts via `darwin/monitoring.nix` by extending the
+agent's `EnvironmentVariables` to point at this directory.
+
+Until then these sensors work as standalone utilities — pipe them into
+anything: Prometheus textfile collector, a cron job writing CSV, a tail
+script shipping to InfluxDB, etc.

--- a/scripts/beszel-sensors/power.sh
+++ b/scripts/beszel-sensors/power.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# ABOUTME: Custom sensor — prints the current total power draw (W) as a single float (Story 08.4-002)
+# ABOUTME: One-line stdout value for consumers like Beszel custom sensors / Prometheus exporters / logging pipelines
+
+# Reads from the health-api /metrics endpoint (cached, 2s TTL), so calling this
+# frequently has no compounding cost. Output is a single decimal number on
+# stdout (e.g. "23.4"). Silent on failure (prints nothing, exits 1) so callers
+# can distinguish missing data from zero draw.
+
+METRICS_URL="${SKETCHYBAR_METRICS_URL:-http://localhost:7780/metrics}"
+
+curl -sf --max-time 2 "$METRICS_URL" \
+  | jq -r '.power.total_watts // empty' \
+  | grep -E '^[0-9]+(\.[0-9]+)?$' \
+  || exit 1

--- a/scripts/beszel-sensors/temp.sh
+++ b/scripts/beszel-sensors/temp.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# ABOUTME: Custom sensor — prints the hottest silicon temperature (°C) as a single float (Story 08.4-002)
+# ABOUTME: max(cpu_temp_c, gpu_temp_c); one-line stdout value for external time-series consumers
+
+# See power.sh — same contract: single number on stdout, silent-failure exit 1.
+
+METRICS_URL="${SKETCHYBAR_METRICS_URL:-http://localhost:7780/metrics}"
+
+curl -sf --max-time 2 "$METRICS_URL" \
+  | jq -r '[.thermal.cpu_temp_c // 0, .thermal.gpu_temp_c // 0] | max' \
+  | grep -E '^[0-9]+(\.[0-9]+)?$' \
+  || exit 1

--- a/scripts/beszel-sensors/temp_gpu.sh
+++ b/scripts/beszel-sensors/temp_gpu.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+# ABOUTME: Custom sensor — prints GPU temperature (°C) as a single float (Story 08.4-002)
+
+METRICS_URL="${SKETCHYBAR_METRICS_URL:-http://localhost:7780/metrics}"
+
+curl -sf --max-time 2 "$METRICS_URL" \
+  | jq -r '.thermal.gpu_temp_c // empty' \
+  | grep -E '^[0-9]+(\.[0-9]+)?$' \
+  || exit 1


### PR DESCRIPTION
## Summary
Scaffolding for the power/temperature time series. Three pull-based sensors under `scripts/beszel-sensors/` that each print a single float from the local `/metrics` endpoint. Usable with any time-series consumer; Beszel wiring deferred until upstream adds a program-sensor hook on macOS.

## Scripts
| Script | Output | Source field |
|--------|--------|--------------|
| `power.sh` | total watts | `.power.total_watts` |
| `temp.sh` | hottest silicon °C | `max(.thermal.cpu_temp_c, .thermal.gpu_temp_c)` |
| `temp_gpu.sh` | GPU °C only | `.thermal.gpu_temp_c` |

Contract: single-line stdout on success, exit 1 with no stdout on failure. Safe to poll at any frequency — `/metrics` already caches on a 2s TTL.

## Why this is scaffolding
Story 08.4-002 originally targeted first-class Beszel integration. Reality: `beszel-agent` on macOS doesn't expose a generic custom-metric interface (its `SYS_SENSORS` and `EXTRA_FS` are Linux-specific). So the scripts land as useful standalone utilities and the README documents how to wire them once upstream supports it (or to any other backend — Prometheus textfile collector, a cron shipper to InfluxDB, etc.).

## Files
- **New**: `scripts/beszel-sensors/power.sh`
- **New**: `scripts/beszel-sensors/temp.sh`
- **New**: `scripts/beszel-sensors/temp_gpu.sh`
- **New**: `scripts/beszel-sensors/README.md` — design notes + Beszel integration deferment

No `darwin/monitoring.nix` changes — no LaunchAgent yet, since there's no consumer to feed.

## Test plan
- [ ] `scripts/beszel-sensors/power.sh` prints a number when `health-api` is up
- [ ] Same exits 1 with no stdout when `health-api` is down
- [ ] `temp.sh` returns `max(cpu,gpu)` — try `stress-ng --cpu 12 --timeout 20` and re-read
- [ ] `sh -n` passes on all three (verified)

## Risk
None — purely new files in a new directory, no LaunchAgent added, no existing behavior touched.

Implements Story 08.4-002, closes #258.

🤖 Generated with [Claude Code](https://claude.com/claude-code)