### PR TITLE
fix(health-api+sketchybar): resolve "health-api not responding" noise

### DIFF
--- a/config/sketchybar/plugins/system.sh
+++ b/config/sketchybar/plugins/system.sh
@@ -32,7 +32,11 @@ fi
 
 METRICS_URL="${SKETCHYBAR_METRICS_URL:-http://localhost:7780/metrics}"
 
-JSON=$(curl -s --max-time 1 "$METRICS_URL" 2>/dev/null)
+# --max-time budget: macmon sampling takes 1-2s on a cold 2s-TTL cache, so a
+# 1s budget guarantees a timeout every other tick. 3s gives the cold path
+# room to breathe while the warm path (within 2s cache TTL) still returns
+# in <100ms — bar perceived latency is unchanged for most ticks.
+JSON=$(curl -s --max-time 3 "$METRICS_URL" 2>/dev/null)
 if [ -z "$JSON" ]; then
   sketchybar --trigger system_metrics_update STALE=1
   exit 0

--- a/scripts/health-api.py
+++ b/scripts/health-api.py
@@ -561,11 +561,17 @@ class HealthHandler(BaseHTTPRequestHandler):
 
     def _respond(self, code: int, body: dict):
         payload = json.dumps(body, indent=2).encode()
-        self.send_response(code)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(payload)))
-        self.end_headers()
-        self.wfile.write(payload)
+        try:
+            self.send_response(code)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+        except (BrokenPipeError, ConnectionResetError):
+            # The client (typically SketchyBar's system.sh with --max-time)
+            # disconnected before we finished writing. Noise, not an error —
+            # the cached response is already populated for the next request.
+            pass
 
     def log_message(self, format, *args):
         # Suppress default stderr logging; write to stdout instead


### PR DESCRIPTION
## Problem
After Wave 4 merged and FX rebuilt:
- SketchyBar shows "⚠ health-api not responding" on the vitals popup click
- `/tmp/health-api.err` spams BrokenPipeError / ConnectionResetError tracebacks

But `launchctl list | rg health-api` shows **exit status 0, pid 4531** — the server is fine.

## Root cause
Two things, both orthogonal to any single Wave 4 PR:

### 1. `system.sh` curl timeout too tight
```
curl -s --max-time 1 "$METRICS_URL"
```
macmon sampling inside `/metrics` takes 1–2s on a cold 2s-TTL cache. A 1s budget means the client disconnects ~every other tick. Warm-cache hits return in <100ms, but cold hits always miss the window.

**Fix**: bump `--max-time` to 3. Bar tick cadence is still ≥2s, so worst-case perceived latency is unchanged.

### 2. Client-disconnect tracebacks pollute stderr
Python's `ThreadingHTTPServer` wraps each request in a try; when `sendall()` raises because the client went away, the traceback dumps to stderr.

**Fix**: narrow `try/except (BrokenPipeError, ConnectionResetError)` wrapping `_respond`'s send sequence. Other exceptions still propagate and log normally.

## Why this wasn't a regression introduced by any specific Wave 4 PR
The 1s timeout originated in #249. It was only exposed when Wave 4 consumers (cpu.p/cpu.e/gpu/ane/power/temp/memory) started rendering STALE=1 as visibly dim items and the vitals popup surfaced the curl-timeout error on click.

## Future work (not in this PR)
Move macmon sampling behind a background refresher thread (same pattern as `_nix_store_refresher`) so `/metrics` never pays the sampling cost on the request path. Would drop cold-path latency to <10ms regardless of TTL expiry. Tracking as a follow-up.

## Test plan
- [ ] Merge and wait for `sketchybar --reload` (plugins are symlinked; no rebuild needed)
- [ ] `launchctl kickstart -k gui/$UID/org.nixos.health-api` to pick up the Python change
- [ ] Wait ~5s, then `oldcat /tmp/health-api.err` → no new BrokenPipeError tracebacks
- [ ] Click cpu.p → vitals popup shows real data (cluster, freq, memory, power, temps, top-5)
- [ ] Bar CPU/GPU/ANE/power/temp items no longer dimmed stale

## Risk
Trivial — one new try/except (narrow exception tuple), one timeout constant change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)