### PR TITLE
Install OSV Scanner for SDLC controller

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -42,6 +42,7 @@ in
     brews = [
       "gh" # GitHub CLI - Required for automated SSH key upload in bootstrap
       "mas" # Mac App Store CLI - Required for masApps installations (Issue #25)
+      "osv-scanner" # OSV Scanner - Vulnerability scanning for the SDLC controller
       "pkgconf" # pkg-config implementation required by native Python extension builds
 
       # AI & LLM Tools

--- a/tests/package_manager_boundaries.bats
+++ b/tests/package_manager_boundaries.bats
@@ -37,6 +37,11 @@ setup() {
     [ "$status" -eq 1 ]
 }
 
+@test "SDLC controller dependency is installed through Homebrew" {
+    run rg -n '"osv-scanner"[[:space:]]+# OSV Scanner' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+}
+
 @test "Homebrew Starship bridge remains explicit" {
     run rg -n '"starship"[[:space:]]+# Starship prompt binary' "$HOMEBREW_CONFIG"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary
- install the Homebrew osv-scanner formula on every profile
- document its SDLC controller ownership
- add package-manager regression coverage

## Verification
- nix develop --command make check