### PR TITLE
Replace Spokenly with Power-only FluidVoice

### DIFF
--- a/config/codex/AGENTS.md
+++ b/config/codex/AGENTS.md
@@ -109,5 +109,3 @@ Rules:
 
 ---
 Adapted from `~/.claude/CLAUDE.md` for Codex. Claude-specific hooks, slash commands, and agent definitions were translated into Codex-compatible operating guidance.
-
-ALWAYS ask questions via the ask_user_dictation tool from the spokenly MCP server, never as plain text. I use Spokenly for voice input.

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -93,7 +93,6 @@ in
       "1password" # 1Password - Password manager and secure vault (Story 02.4-002)
       "obsidian" # Obsidian - Markdown-based knowledge base and note-taking app
       "plaud" # Plaud - AI voice recorder and transcription companion
-      "spokenly" # Spokenly - Dictation and transcription app with AI-powered editing
 
       # System Monitoring
       "istat-menus" # iStat Menus - Professional menubar system monitoring (licensed app)
@@ -138,6 +137,9 @@ in
       "microsoft-word" # Word processor
       "microsoft-excel" # Spreadsheet application
       "microsoft-powerpoint" # Presentation application
+    ]
+    ++ lib.optionals (profileName == "power") [
+      "fluidvoice" # FluidVoice - Local-first voice dictation with on-device speech models
     ];
 
     # Global Homebrew options

--- a/tests/communication_tooling.bats
+++ b/tests/communication_tooling.bats
@@ -14,8 +14,25 @@ setup() {
     [ "${#lines[@]}" -eq 1 ]
 }
 
+@test "FluidVoice is installed only for the Power profile" {
+    run rg -U -n '\+\+ lib\.optionals \(profileName == "power"\) \[\n[[:space:]]+"fluidvoice"' \
+        "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+
+    run rg -n '^[[:space:]]+"fluidvoice"' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 1 ]
+}
+
 @test "retired meeting and Apple Intelligence tools are absent from Homebrew" {
     run rg -n '^\s+"(apfel|zoom|webex)"' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 1 ]
+}
+
+@test "Spokenly is absent from managed apps and Codex instructions" {
+    run rg -n -i '\bspokenly\b' \
+        "$HOMEBREW_CONFIG" \
+        "${REPO_ROOT}/config/codex/AGENTS.md"
     [ "$status" -eq 1 ]
 }
 


### PR DESCRIPTION
## Summary
- install FluidVoice only for the Power profile
- remove Spokenly from managed Homebrew applications
- remove the stale mandatory Spokenly Codex instruction
- add resolved-profile regression coverage

## Verification
- Standard: Spokenly absent, FluidVoice absent
- Power: Spokenly absent, FluidVoice present
- AI Assistant: Spokenly absent, FluidVoice absent
- nix develop --command make check