### PR TITLE
docs: add epic-11 cloud archive tier stories

### DIFF
--- a/STORIES.md
+++ b/STORIES.md
@@ -54,6 +54,7 @@ Comprehensive user story organization for the Nix-Darwin MacBook Setup System wi
 | Epic-08 | Resource Optimization & Deep Telemetry | Post-v1.0 disk/memory leaks closed and mactop-grade bar telemetry | 23 | 118 | Should Have |
 | Epic-09 | Local PII Redaction (MLX Privacy Filter) | On-device PII scrubbing before text reaches a cloud LLM | 8 committed (+11 proposed) | TBD | Should Have |
 | Epic-10 | Bootstrap Integrity & Security Hardening | Fix broken fresh installs; tag-pinned clone-first bootstrap; P0 security fixes | 13 | 38 | Must Have |
+| Epic-11 | Cloud Archive Tier | B2 offsite archive pipeline (3-2-1) for irreplaceable cold data | 4 | 13 | Must Have |
 | NFR | Non-Functional Requirements | Performance, security, reliability | 15 | 79 | Must Have |
 
 ## Epic Navigation
@@ -67,6 +68,7 @@ Comprehensive user story organization for the Nix-Darwin MacBook Setup System wi
 - **[Epic-08: Resource Optimization & Deep Telemetry](./stories/epic-08-resource-optimization.md)** - System-level GC, Huggingface/browser cache pruning, Ollama memory tuning, SketchyBar `/metrics` consolidation
 - **Epic-09: Local PII Redaction** - MLX-backed Privacy Filter daemon on `127.0.0.1:7790` with `redact` / `redact-clip` helpers. No story file yet (Story 09.4-001); scope lives in [issue #303](https://github.com/fxmartin/nix-install/issues/303)
 - **[Epic-10: Bootstrap Integrity & Security Hardening](./stories/epic-10-bootstrap-integrity-security.md)** - Clone-first tag-pinned bootstrap (fixes broken fresh installs), root-shell/credential hardening, CI & drift cleanup from the 2026-07-28 review
+- **[Epic-11: Cloud Archive Tier](./stories/epic-11-cloud-archive-tier.md)** - Backblaze B2 + rclone archive pipeline (bundle → upload → verify → ledger) for irreplaceable cold data identified in the 2026-08-02 storage audit
 - **[Non-Functional Requirements](./stories/non-functional-requirements.md)** - Performance, security, reliability, maintainability
 
 ## MVP Summary
@@ -105,13 +107,14 @@ Comprehensive user story organization for the Nix-Darwin MacBook Setup System wi
 - **2026-04-22**: Epic-08 22/23 shipped (all P0 + all P2 + 7/8 P1). Only 08.3-008 (mactop retirement validation) outstanding.
 - **2026-05-07**: Epic-09 (Local PII Redaction) added — Feature 09.1 (8 stories) is the only committed scope; Features 09.2/09.3/09.4 (11 stories) are proposed sketches pending a scope decision, so the epic carries no point total yet.
 - **2026-07-28**: Epic-10 (Bootstrap Integrity & Security Hardening) added from the 2026-07-28 full-repo review — opened at 12 stories / 43 points, closed at 13 stories / 38 points after 10.4-004 was added and the estimates were reconciled against the ledger.
+- **2026-08-02**: Epic-11 (Cloud Archive Tier) added from the 2026-08-02 storage audit — 4 stories / 13 points. Driver: the 186GB LTIMindtree OneDrive final copy exists only on the NAS; B2 chosen over Glacier Deep Archive for restore ergonomics at ≤400GB scale.
 
 ## Project Metrics
-- **Total Stories**: 169 (125 MVP + 23 Epic-08 + 8 Epic-09 committed + 13 Epic-10)
-- **Total Story Points**: 814 (658 MVP + 118 Epic-08 + 38 Epic-10; Epic-09 unestimated)
+- **Total Stories**: 173 (125 MVP + 23 Epic-08 + 8 Epic-09 committed + 13 Epic-10 + 4 Epic-11)
+- **Total Story Points**: 827 (658 MVP + 118 Epic-08 + 38 Epic-10 + 13 Epic-11; Epic-09 unestimated)
 - **Average Story Size**: 5.1 points
-- **Completed Stories**: 166 (98.2%)
-- **Completed Points**: 810 (99.5%)
+- **Completed Stories**: 166 (96.0%)
+- **Completed Points**: 810 (97.9%)
 - **MVP Completion**: 99.2% by stories, 99.5% by points
 - **🎉 MILESTONE**: MacBook Pro M3 Max successfully running Power profile (2025-12-07)
 - **🎉 MILESTONE**: Epic-08 Resource Optimization & Deep Telemetry — 22/23 stories shipped over 18 hours (2026-04-21 to 2026-04-22)

--- a/stories/epic-11-cloud-archive-tier.md
+++ b/stories/epic-11-cloud-archive-tier.md
@@ -1,0 +1,65 @@
+# Epic 11: Cloud Archive Tier
+
+## Epic Overview
+**Epic ID**: Epic-11
+**Epic Description**: Add a cloud cold-storage tier (Backblaze B2 via rclone) below the NAS, so irreplaceable data gets an offsite copy (3-2-1) and cold data can be evicted from the NAS/SSD with confidence. Born from the 2026-08-02 storage audit: the NAS held 9.0TB of which 7.8TB was unmanaged Time Machine growth, and `Data/Archives/LTIMindtree-OneDrive-final-copy-2025-11` (186GB of FX's ex-employer OneDrive/SharePoint data, account access gone) exists as a **single copy on a single device**.
+**Business Value**: Eliminates the single-point-of-failure risk on irreplaceable personal/professional archives for <$3/month; unlocks guilt-free deletion of cold data from the warm tiers.
+**User Impact**: FX gets a verified, checksummed offsite copy of anything declared "archive", a repeatable bundle→upload→verify pipeline runnable over SSH against the NAS, and a written ledger of what lives in the cloud.
+**Success Metrics**:
+- LTIMindtree archive (186GB) and Outlook 2014 archive (~4GB) exist in B2 with verified SHA256 checksums
+- Every archive bundle has a manifest entry (source path, date, size, SHA256, B2 object) in the archive ledger
+- A test restore of at least one bundle has been performed and checksum-verified
+- Total monthly cloud cost ≤ $3 at current volumes
+
+## Epic Scope
+**Total Stories**: 4
+**Total Story Points**: 13
+**MVP Stories**: 4 (100% — single feature)
+**Priority Level**: Must Have (data-loss risk mitigation)
+**Target Release**: v2.2.0
+**Status**: 📋 Planned
+
+## Features in This Epic
+
+> **Note**: Detailed story implementations live in `stories/features/` following the Epic-06 pattern.
+
+### Feature 11.1: B2 Archive Pipeline 📋
+**Feature Description**: rclone + B2 remote setup, `nas-archive.sh` bundling script (tar.zst + SHA256 manifest, runs on the NAS over SSH), upload+verify workflow with archive ledger, and execution of the first two archives (LTIMindtree, Outlook 2014)
+**Story Count**: 4 | **Story Points**: 13 | **Priority**: Must Have (P0) | **Complexity**: Medium
+**Status**: 📋 0/4
+👉 **[View detailed implementation](features/epic-11-feature-11.1.md)**
+
+## Epic Dependencies
+
+### Dependencies on Other Epics
+- **Epic-06/08 (Maintenance)**: Reuses `send-notification.sh` failure-email pattern if archive jobs are later scheduled
+- **NAS access**: Requires the TNAS SSH access established 2026-08-02 (port 2222, `id_ed25519`; see session memory `tnas-ssh-access-via-nas-lux`)
+
+### Stories This Epic Enables
+- Future retention policy for the rsync archive-mode mirrors (deletions age out to B2 instead of accumulating forever on the NAS)
+- Future NAS-side scheduled archive sweeps (e.g. `Backup/nyx`, old Photos exports)
+
+### Stories This Epic Blocks
+- Deletion of the NAS `LTIMindtree-OneDrive-final-copy-2025-11` "only copy" status — nothing may delete that tree until 11.1-004 is verified complete
+
+## Epic Delivery Planning
+
+### Sprint Breakdown
+| Sprint | Stories | Story Points | Sprint Goal |
+|--------|---------|--------------|-------------|
+| Sprint 15 | 11.1-001 to 11.1-004 | 13 | Verified offsite copies of all declared-irreplaceable data |
+
+### Risk Assessment
+**Low Risk Items**:
+- All operations are additive (uploads); no source data is modified or deleted by any story
+- rclone is mature and idempotent (`copy` never deletes)
+
+**Medium Risk Items**:
+- **Large upload (186GB)**: home upstream bandwidth may make the first upload multi-day. Mitigation: rclone resumes cleanly; run in `tmux` on the NAS; `--bwlimit` schedule to avoid saturating the line.
+- **Credential handling**: B2 keys must never enter git. Mitigation: follow the existing untracked-file pattern (`~/.config/rclone/rclone.conf` on the NAS, chmod 600, documented in the feature file).
+
+## Epic Progress Tracking
+
+### Completion Status _(as of 2026-08-02)_
+- **Stories Completed**: 0 of 4 (0%)
+- **Story Points Completed**: 0 of 13 (0%)

--- a/stories/features/epic-11-feature-11.1.md
+++ b/stories/features/epic-11-feature-11.1.md
@@ -1,0 +1,120 @@
+# ABOUTME: Epic-11 Feature 11.1 (B2 Archive Pipeline) implementation details
+# ABOUTME: rclone/B2 setup, NAS-side bundling script, upload+verify workflow, first archive executions
+
+# Epic-11 Feature 11.1: B2 Archive Pipeline
+
+## Feature Overview
+
+**Feature ID**: Feature 11.1
+**Feature Name**: B2 Archive Pipeline
+**Epic**: Epic-11
+**Status**: 📋 Planned
+
+### Feature 11.1: B2 Archive Pipeline
+**Feature Description**: Stand up a Backblaze B2 bucket with rclone access from the NAS, build a bundling script that turns any NAS directory into a checksummed `tar.zst` archive, define the upload+verify+ledger workflow, and execute it for the two archives identified in the 2026-08-02 audit.
+**User Value**: Irreplaceable data gains a verified offsite copy; cold data becomes safely deletable from warm tiers
+**Story Count**: 4
+**Story Points**: 13
+**Priority**: Must Have (P0)
+**Complexity**: Medium
+
+#### Stories in This Feature
+
+---
+
+##### Story 11.1-001: rclone + B2 Remote Setup
+**User Story**: As FX, I want rclone installed on the NAS and configured against a new B2 bucket so that archives can upload directly from the NAS without transiting the Mac
+
+**Priority**: Must Have
+**Story Points**: 3
+**Sprint**: Sprint 15
+
+**Acceptance Criteria**:
+- **Given** a B2 account with a new private bucket (e.g. `fxm-archive`) and an application key scoped to that bucket
+- **When** `rclone lsd b2-archive:` runs on the NAS over SSH
+- **Then** it lists the bucket without error
+- **And** `~/.config/rclone/rclone.conf` on the NAS is chmod 600 and never enters git
+- **And** the bucket has default encryption enabled and no lifecycle rule that auto-deletes
+
+**Technical Notes**:
+- NAS is x86_64 Linux (TOS 6, kernel 6.1) — install the static rclone binary to `~/bin/rclone` on the NAS (no TOS package needed); document the install command in the story PR
+- SSH access: `ssh -i ~/.ssh/id_ed25519 -o IdentitiesOnly=yes -p 2222 fxmartin@tnas.local`
+- Consider `rclone config` crypt overlay later; NOT in scope (B2 server-side encryption + private bucket suffices for v1)
+- Decision recorded 2026-08-02: **B2 over S3 Glacier Deep Archive** — instant access, free egress up to 3× stored, `rclone check` verification; at ≤400GB total the ~$6/TB/mo premium is negligible vs restore ergonomics
+
+---
+
+##### Story 11.1-002: `nas-archive.sh` Bundling Script
+**User Story**: As FX, I want a script that bundles any NAS directory into a `tar.zst` + SHA256 manifest so that archives are single objects with verifiable integrity
+
+**Priority**: Must Have
+**Story Points**: 5
+**Sprint**: Sprint 15
+
+**Acceptance Criteria**:
+- **Given** `nas-archive.sh bundle <source-dir> <archive-name>` run on the NAS
+- **When** it completes
+- **Then** `/Volume1/Data/Archives/_staging/<archive-name>.tar.zst` exists
+- **And** `<archive-name>.sha256` contains the bundle checksum
+- **And** `<archive-name>.filelist.txt.zst` contains the full file listing (so contents are searchable without a restore)
+- **And** the script refuses to run if staging free space < source size
+- **And** re-running with an existing bundle name aborts (no silent overwrite)
+
+**Additional Requirements**:
+- `set -euo pipefail` with the pipeline guards documented in CLAUDE.md (Shell & Script Gotchas)
+- Progress output suitable for `tmux` sessions (multi-hour runs on 186GB)
+- Lives in `scripts/nas-archive.sh` in this repo; synced to NAS `~/bin/` manually or via the story PR's documented step
+
+**Technical Notes**:
+- `tar -I 'zstd -T0 -10' -cf` — zstd level 10 multithread; F8 SSD NAS has cycles to spare
+- Checksum with `sha256sum` (Linux) — do not reuse macOS `shasum` syntax
+- bats tests for argument validation / refusal paths run against a temp dir (safe suite)
+
+---
+
+##### Story 11.1-003: Upload + Verify + Ledger Workflow
+**User Story**: As FX, I want `nas-archive.sh upload <archive-name>` to push a bundle to B2, verify it, and record it in a ledger so that "archived" always means "verified offsite"
+
+**Priority**: Must Have
+**Story Points**: 3
+**Sprint**: Sprint 15
+
+**Acceptance Criteria**:
+- **Given** a staged bundle from 11.1-002
+- **When** `nas-archive.sh upload <archive-name>` completes
+- **Then** the bundle + `.sha256` + `.filelist.txt.zst` exist in `b2-archive:fxm-archive/<archive-name>/`
+- **And** `rclone check` (or `rclone sha1sum`/size comparison) confirms integrity and is logged
+- **And** `/Volume1/Data/Archives/LEDGER.md` gains a row: date, archive name, source path, size, SHA256, B2 path
+- **And** the workflow prints an explicit reminder that source deletion is a separate, manual decision
+
+**Technical Notes**:
+- `rclone copy --transfers 4 --checkers 8 --bwlimit "08:00,2M 23:00,off"` — tune to home upstream; resumable
+- Ledger is markdown on the NAS **and** mirrored into `docs/archives/LEDGER.md` in this repo (repo copy is the durable index; no secrets in it)
+- Failure → non-zero exit; email integration via `send-notification.sh` only if/when scheduled (not in scope)
+
+---
+
+##### Story 11.1-004: Execute First Archives (LTIMindtree + Outlook 2014)
+**User Story**: As FX, I want the LTIMindtree OneDrive copy and the 2014 Outlook archives bundled, uploaded, verified, and test-restored so that no irreplaceable data has a single copy
+
+**Priority**: Must Have
+**Story Points**: 2
+**Sprint**: Sprint 15
+
+**Acceptance Criteria**:
+- **Given** stories 11.1-001..003 complete
+- **When** the pipeline runs for both sources
+- **Then** B2 contains verified bundles for:
+  - `/Volume1/Data/Archives/LTIMindtree-OneDrive-final-copy-2025-11` (~186GB source)
+  - `/Volume1/icloud/Documents/00. Archives` (Outlook 2014 mbox + `OffLineArchive.pst`, ~4GB)
+- **And** one bundle (the small one) is downloaded back, checksum-verified, and opened as a restore test
+- **And** LEDGER.md records both archives and the restore test
+- **And** the `README.txt` in the LTIMindtree folder is updated: "only remaining copy" → "offsite copy verified <date>, B2 <path>"
+
+**Additional Requirements**:
+- The NAS source trees are NOT deleted in this story — eviction decisions are explicitly out of scope
+- Multi-day upload acceptable; run in `tmux` on the NAS
+
+**Technical Notes**:
+- 186GB at typical 20–50 Mbit/s upstream ≈ 9–20 hours minimum; `--bwlimit` daytime throttle recommended
+- After this story, monthly B2 cost ≈ $1.20 at ~200GB


### PR DESCRIPTION
Adds Epic-11 (Cloud Archive Tier): 4 stories / 13 points for a Backblaze B2 offsite archive pipeline (bundle → upload → verify → ledger), born from the 2026-08-02 storage audit. The 186GB LTIMindtree OneDrive final copy currently exists only on the NAS — this epic closes that single-copy risk.

- New: `stories/epic-11-cloud-archive-tier.md`, `stories/features/epic-11-feature-11.1.md`
- Updated: `STORIES.md` index (epic table, navigation, change history, totals → 173 stories / 827 points)
- Story issues: #408 #409 #410 #411

Docs-only change; no code or config touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)