### PR TITLE
feat(archive): add nas-archive.sh bundle command

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,443 test cases (46 BATS files, 295 in the active gate) |
+| **Tests** | 1,447 test cases (46 BATS files, 299 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 35 casks (19 on AI-Assistant), 7 brews, 8 MAS, 50+ Nix |

--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,432 test cases (45 BATS files, 284 in the active gate) |
+| **Tests** | 1,443 test cases (46 BATS files, 295 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 35 casks (19 on AI-Assistant), 7 brews, 8 MAS, 50+ Nix |

--- a/darwin/smb-automount.nix
+++ b/darwin/smb-automount.nix
@@ -88,7 +88,7 @@ in
       echo "  Removed stale /etc/auto_smb (autofs no longer used)"
     fi
     if [[ -f /etc/auto_master ]] && grep -q 'auto_smb' /etc/auto_master; then
-      sed -i ''' '/auto_smb/d' /etc/auto_master
+      sed -i.bak '/auto_smb/d' /etc/auto_master && rm -f /etc/auto_master.bak
       automount -vc >/dev/null 2>&1 || true
       echo "  Removed auto_smb entry from /etc/auto_master"
     fi

--- a/scripts/codex-cleanup.sh
+++ b/scripts/codex-cleanup.sh
@@ -209,7 +209,7 @@ compact_logs() {
         return 0
     fi
 
-    before_bytes="$(stat -f '%z' "${CODEX_LOGS_DB}")"
+    before_bytes="$(/usr/bin/stat -f '%z' "${CODEX_LOGS_DB}")"
     ensure_compaction_space "${before_bytes}"
 
     printf 'Compacting %s (%s reclaimable)...\n' \
@@ -229,7 +229,7 @@ SQL
         return 1
     fi
 
-    after_bytes="$(stat -f '%z' "${CODEX_LOGS_DB}")"
+    after_bytes="$(/usr/bin/stat -f '%z' "${CODEX_LOGS_DB}")"
     printf 'Log database compacted: %s -> %s.\n' \
         "$(format_bytes "${before_bytes}")" "$(format_bytes "${after_bytes}")"
 }

--- a/scripts/nas-archive.sh
+++ b/scripts/nas-archive.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# ABOUTME: Bundles a NAS directory into a checksummed tar.zst archive for the B2 archive pipeline
+# ABOUTME: Story 11.1-002 - staging free-space guard and no-overwrite guard; upload lands in 11.1-003
+
+set -euo pipefail
+
+NAS_ARCHIVE_VERSION="1.0.0"
+
+# Staging directory can be overridden for testing; defaults to the NAS path
+# from the story's acceptance criteria.
+STAGING_DIR="${NAS_ARCHIVE_STAGING_DIR:-/Volume1/Data/Archives/_staging}"
+
+usage() {
+    cat <<'EOF'
+Usage: nas-archive.sh bundle <source-dir> <archive-name>
+
+Bundles <source-dir> into a checksummed tar.zst archive under the staging
+directory (default /Volume1/Data/Archives/_staging, override with
+NAS_ARCHIVE_STAGING_DIR).
+
+Produces in the staging directory:
+  <archive-name>.tar.zst           the compressed bundle
+  <archive-name>.sha256            sha256sum manifest of the bundle
+  <archive-name>.filelist.txt.zst  compressed listing of bundled files
+
+Refuses to run if staging free space is less than the source size, and
+refuses to overwrite an existing bundle with the same name.
+EOF
+}
+
+log() {
+    printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$1"
+}
+
+die() {
+    printf 'Error: %s\n' "$1" >&2
+    exit 1
+}
+
+# Restrict archive names to a safe filename character set so they cannot
+# escape the staging directory or collide with tar/zstd option parsing.
+validate_archive_name() {
+    local name="$1"
+    [[ "${name}" =~ ^[A-Za-z0-9._-]+$ ]] \
+        || die "archive name must contain only letters, numbers, dots, dashes, underscores: ${name}"
+}
+
+cmd_bundle() {
+    local source_dir="${1:-}"
+    local archive_name="${2:-}"
+
+    if [[ -z "${source_dir}" || -z "${archive_name}" ]]; then
+        usage >&2
+        exit 1
+    fi
+
+    [[ -d "${source_dir}" ]] || die "source directory does not exist: ${source_dir}"
+    validate_archive_name "${archive_name}"
+
+    mkdir -p "${STAGING_DIR}"
+
+    local archive_path="${STAGING_DIR}/${archive_name}.tar.zst"
+    local sha_path="${STAGING_DIR}/${archive_name}.sha256"
+    local filelist_path="${STAGING_DIR}/${archive_name}.filelist.txt.zst"
+
+    if [[ -e "${archive_path}" ]]; then
+        die "bundle already exists, refusing to overwrite: ${archive_path}"
+    fi
+
+    log "Computing source size for ${source_dir}"
+    local source_size_kb
+    source_size_kb=$(du -sk "${source_dir}" | awk '{print $1}')
+    [[ -n "${source_size_kb}" ]] || die "could not determine source size for ${source_dir}"
+
+    log "Checking staging free space in ${STAGING_DIR}"
+    local free_kb
+    free_kb=$(df -k "${STAGING_DIR}" | awk 'NR==2 {print $4}')
+    [[ -n "${free_kb}" ]] || die "could not determine free space for ${STAGING_DIR}"
+
+    if (( free_kb < source_size_kb )); then
+        die "insufficient staging free space: need ${source_size_kb}KB, have ${free_kb}KB in ${STAGING_DIR}"
+    fi
+
+    log "Bundling ${source_dir} -> ${archive_path}"
+    tar -I 'zstd -T0 -10' -cf "${archive_path}" -C "${source_dir}" .
+    log "Bundle created: ${archive_path}"
+
+    log "Writing checksum manifest"
+    (cd "${STAGING_DIR}" && sha256sum "${archive_name}.tar.zst" > "${archive_name}.sha256")
+
+    log "Writing compressed file listing"
+    tar -I 'zstd -T0 -10' -tf "${archive_path}" | zstd -q -T0 -o "${filelist_path}"
+
+    log "Bundle complete:"
+    log "  archive:  ${archive_path}"
+    log "  checksum: ${sha_path}"
+    log "  filelist: ${filelist_path}"
+}
+
+main() {
+    local subcommand="${1:-}"
+
+    case "${subcommand}" in
+        bundle)
+            shift
+            cmd_bundle "$@"
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        "")
+            usage >&2
+            exit 1
+            ;;
+        *)
+            printf 'Error: unknown subcommand: %s\n' "${subcommand}" >&2
+            usage >&2
+            exit 1
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/nas-archive.sh
+++ b/scripts/nas-archive.sh
@@ -4,8 +4,6 @@
 
 set -euo pipefail
 
-NAS_ARCHIVE_VERSION="1.0.0"
-
 # Staging directory can be overridden for testing; defaults to the NAS path
 # from the story's acceptance criteria.
 STAGING_DIR="${NAS_ARCHIVE_STAGING_DIR:-/Volume1/Data/Archives/_staging}"
@@ -69,12 +67,12 @@ cmd_bundle() {
 
     log "Computing source size for ${source_dir}"
     local source_size_kb
-    source_size_kb=$(du -sk "${source_dir}" | awk '{print $1}')
+    source_size_kb=$(du -sk "${source_dir}" | awk '{print $1}' || true)
     [[ -n "${source_size_kb}" ]] || die "could not determine source size for ${source_dir}"
 
     log "Checking staging free space in ${STAGING_DIR}"
     local free_kb
-    free_kb=$(df -k "${STAGING_DIR}" | awk 'NR==2 {print $4}')
+    free_kb=$(df -k "${STAGING_DIR}" | awk 'NR==2 {print $4}' || true)
     [[ -n "${free_kb}" ]] || die "could not determine free space for ${STAGING_DIR}"
 
     if (( free_kb < source_size_kb )); then

--- a/stories/features/epic-11-feature-11.1.md
+++ b/stories/features/epic-11-feature-11.1.md
@@ -50,6 +50,7 @@
 **Priority**: Must Have
 **Story Points**: 5
 **Sprint**: Sprint 15
+**Status**: ✅ Code Complete (Pending FX NAS Validation) — `scripts/nas-archive.sh` `bundle` subcommand + `tests/nas_archive.bats` (arg validation, no-overwrite, free-space refusal); real bundling requires GNU `tar`/`sha256sum` on the NAS and has not been run against the NAS yet
 
 **Acceptance Criteria**:
 - **Given** `nas-archive.sh bundle <source-dir> <archive-name>` run on the NAS

--- a/tests/codex_cleanup_test.sh
+++ b/tests/codex_cleanup_test.sh
@@ -30,6 +30,7 @@ printf 'browser cache\n' >"${codex_cache_dir}/Default/cache.bin"
 
 sqlite3 "${codex_dir}/logs_2.sqlite" >/dev/null <<'SQL'
 PRAGMA journal_mode=DELETE;
+PRAGMA auto_vacuum=NONE;
 CREATE TABLE logs (payload BLOB NOT NULL);
 WITH RECURSIVE sequence(value) AS (
     SELECT 1

--- a/tests/codex_cleanup_test.sh
+++ b/tests/codex_cleanup_test.sh
@@ -97,7 +97,7 @@ if invalid_threshold_output="$(CODEX_CLEANUP_HOME="${test_home}" \
 fi
 [[ "${invalid_threshold_output}" == *"must be a non-negative integer"* ]]
 
-database_before="$(stat -f '%z' "${codex_dir}/logs_2.sqlite")"
+database_before="$(/usr/bin/stat -f '%z' "${codex_dir}/logs_2.sqlite")"
 if open_database_output="$(CODEX_CLEANUP_HOME="${test_home}" \
     CODEX_CLEANUP_LSOF_BIN="${mock_bin_dir}/open-lsof" \
     CODEX_CLEANUP_PGREP_BIN="${mock_bin_dir}/no-processes" \
@@ -107,10 +107,10 @@ if open_database_output="$(CODEX_CLEANUP_HOME="${test_home}" \
     exit 1
 fi
 [[ "${open_database_output}" == *"close Codex before compacting"* ]]
-[[ "$(stat -f '%z' "${codex_dir}/logs_2.sqlite")" -eq "${database_before}" ]]
+[[ "$(/usr/bin/stat -f '%z' "${codex_dir}/logs_2.sqlite")" -eq "${database_before}" ]]
 
 run_cleanup --compact-logs
-database_after="$(stat -f '%z' "${codex_dir}/logs_2.sqlite")"
+database_after="$(/usr/bin/stat -f '%z' "${codex_dir}/logs_2.sqlite")"
 [[ "${database_after}" -lt "${database_before}" ]]
 [[ "$(sqlite3 -readonly "${codex_dir}/logs_2.sqlite" 'PRAGMA integrity_check;')" == "ok" ]]
 assert_exists "${codex_dir}/sessions/2026/07/31/rollout.jsonl"

--- a/tests/nas_archive.bats
+++ b/tests/nas_archive.bats
@@ -1,0 +1,123 @@
+#!/usr/bin/env bats
+# ABOUTME: Story 11.1-002 - argument validation and refusal-path tests for nas-archive.sh
+# ABOUTME: Hermetic - stubs du/df and uses a temp staging dir, never touches the real NAS
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/../scripts/nas-archive.sh"
+    STAGING_DIR="${BATS_TEST_TMPDIR}/staging"
+    SOURCE_DIR="${BATS_TEST_TMPDIR}/source"
+    STUB_BIN="${BATS_TEST_TMPDIR}/bin"
+
+    mkdir -p "${STAGING_DIR}" "${SOURCE_DIR}" "${STUB_BIN}"
+    echo "hello" > "${SOURCE_DIR}/file.txt"
+}
+
+run_nas_archive() {
+    run env PATH="${STUB_BIN}:${PATH}" NAS_ARCHIVE_STAGING_DIR="${STAGING_DIR}" \
+        "${SCRIPT}" "$@"
+}
+
+# =============================================================================
+# Argument validation
+# =============================================================================
+
+@test "no subcommand prints usage and exits non-zero" {
+    run_nas_archive
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: nas-archive.sh bundle"* ]]
+}
+
+@test "--help prints usage and exits 0" {
+    run_nas_archive --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage: nas-archive.sh bundle"* ]]
+}
+
+@test "unknown subcommand is rejected" {
+    run_nas_archive upload some-archive
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"unknown subcommand: upload"* ]]
+}
+
+@test "bundle with missing archive-name argument is rejected" {
+    run_nas_archive bundle "${SOURCE_DIR}"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: nas-archive.sh bundle"* ]]
+}
+
+@test "bundle with missing source-dir argument is rejected" {
+    run_nas_archive bundle
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Usage: nas-archive.sh bundle"* ]]
+}
+
+@test "bundle refuses a source directory that does not exist" {
+    run_nas_archive bundle "${BATS_TEST_TMPDIR}/does-not-exist" my-archive
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"source directory does not exist"* ]]
+}
+
+@test "bundle refuses an archive name with a path separator" {
+    run_nas_archive bundle "${SOURCE_DIR}" "../escape"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"archive name must contain only letters, numbers, dots, dashes, underscores"* ]]
+}
+
+@test "bundle refuses an archive name with a space" {
+    run_nas_archive bundle "${SOURCE_DIR}" "bad name"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"archive name must contain only letters, numbers, dots, dashes, underscores"* ]]
+}
+
+# =============================================================================
+# Refusal paths (AC: no silent overwrite, staging free-space guard)
+# =============================================================================
+
+@test "bundle aborts without overwriting an existing archive" {
+    touch "${STAGING_DIR}/my-archive.tar.zst"
+
+    run_nas_archive bundle "${SOURCE_DIR}" my-archive
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"bundle already exists, refusing to overwrite"* ]]
+
+    # Original (empty) archive must be untouched, not silently replaced.
+    [ ! -s "${STAGING_DIR}/my-archive.tar.zst" ]
+}
+
+@test "bundle aborts when staging free space is less than source size" {
+    cat > "${STUB_BIN}/du" <<'EOF'
+#!/usr/bin/env bash
+echo "999999999	fake-source"
+EOF
+    cat > "${STUB_BIN}/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted-on\n'
+printf 'fake 1000 900 100 90%% /fake\n'
+EOF
+    chmod +x "${STUB_BIN}/du" "${STUB_BIN}/df"
+
+    run_nas_archive bundle "${SOURCE_DIR}" my-archive
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"insufficient staging free space"* ]]
+
+    # No partial archive should be left behind.
+    [ ! -e "${STAGING_DIR}/my-archive.tar.zst" ]
+}
+
+@test "bundle creates the staging directory before running the free-space check" {
+    STAGING_DIR="${BATS_TEST_TMPDIR}/nested/staging"
+    cat > "${STUB_BIN}/du" <<'EOF'
+#!/usr/bin/env bash
+echo "999999999	fake-source"
+EOF
+    cat > "${STUB_BIN}/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted-on\n'
+printf 'fake 1000 900 100 90%% /fake\n'
+EOF
+    chmod +x "${STUB_BIN}/du" "${STUB_BIN}/df"
+
+    run_nas_archive bundle "${SOURCE_DIR}" my-archive
+    [ "$status" -eq 1 ]
+    [ -d "${STAGING_DIR}" ]
+}

--- a/tests/nas_archive.bats
+++ b/tests/nas_archive.bats
@@ -121,3 +121,81 @@ EOF
     [ "$status" -eq 1 ]
     [ -d "${STAGING_DIR}" ]
 }
+
+@test "bundle aborts when du cannot determine source size" {
+    cat > "${STUB_BIN}/du" <<'EOF'
+#!/usr/bin/env bash
+echo ""
+EOF
+    chmod +x "${STUB_BIN}/du"
+
+    run_nas_archive bundle "${SOURCE_DIR}" my-archive
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"could not determine source size"* ]]
+}
+
+@test "bundle aborts when df cannot determine free space" {
+    cat > "${STUB_BIN}/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted-on\n'
+EOF
+    chmod +x "${STUB_BIN}/df"
+
+    run_nas_archive bundle "${SOURCE_DIR}" my-archive
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"could not determine free space"* ]]
+}
+
+# =============================================================================
+# Happy path (bundle creation) - tar/zstd stubbed since BSD tar on the
+# macOS test host does not understand GNU tar's -I compress-program syntax;
+# the real GNU-tooling path runs on the NAS and is covered manually there.
+# =============================================================================
+
+stub_tar() {
+    cat > "${STUB_BIN}/tar" <<'EOF'
+#!/usr/bin/env bash
+args=("$@")
+for i in "${!args[@]}"; do
+    if [[ "${args[$i]}" == "-cf" ]]; then
+        touch "${args[$((i+1))]}"
+        exit 0
+    elif [[ "${args[$i]}" == "-tf" ]]; then
+        printf './file.txt\n'
+        exit 0
+    fi
+done
+exit 1
+EOF
+    chmod +x "${STUB_BIN}/tar"
+}
+
+@test "bundle happy path writes archive, checksum manifest, and filelist" {
+    stub_tar
+
+    run_nas_archive bundle "${SOURCE_DIR}" my-archive
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Bundle complete:"* ]]
+    [ -e "${STAGING_DIR}/my-archive.tar.zst" ]
+    [ -e "${STAGING_DIR}/my-archive.sha256" ]
+    [ -e "${STAGING_DIR}/my-archive.filelist.txt.zst" ]
+    grep -q 'my-archive.tar.zst' "${STAGING_DIR}/my-archive.sha256"
+}
+
+@test "bundle proceeds when free space exactly equals source size" {
+    cat > "${STUB_BIN}/du" <<'EOF'
+#!/usr/bin/env bash
+echo "100	fake-source"
+EOF
+    cat > "${STUB_BIN}/df" <<'EOF'
+#!/usr/bin/env bash
+printf 'Filesystem 1024-blocks Used Available Capacity Mounted-on\n'
+printf 'fake 1000 900 100 90%% /fake\n'
+EOF
+    chmod +x "${STUB_BIN}/du" "${STUB_BIN}/df"
+    stub_tar
+
+    run_nas_archive bundle "${SOURCE_DIR}" boundary-archive
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Bundle complete:"* ]]
+}

--- a/tests/run-safe-suite.sh
+++ b/tests/run-safe-suite.sh
@@ -28,6 +28,7 @@ safe_bats_suites=(
     tests/gitleaks-secrets.bats
     tests/mlx_lm_inferencer.bats
     tests/monitoring_stack.bats
+    tests/nas_archive.bats
     tests/network_security.bats
     tests/office_apps.bats
     tests/ollama_messaging_freshness.bats

--- a/tests/smb_automount_activation.bats
+++ b/tests/smb_automount_activation.bats
@@ -113,7 +113,7 @@ render_activation_script() {
     [ "$status" -eq 0 ]
     [ -f "${CONFIG_FILE}" ]
 
-    run stat -f '%Lp' "${CONFIG_FILE}"
+    run /usr/bin/stat -f '%Lp' "${CONFIG_FILE}"
     [ "$status" -eq 0 ]
     [ "$output" = "600" ]
 
@@ -150,7 +150,7 @@ render_activation_script() {
     [ -f "${MOUNT_SCRIPT_DEST}" ]
     [[ "$output" == *"installed to"* ]]
 
-    run stat -f '%Lp' "${MOUNT_SCRIPT_DEST}"
+    run /usr/bin/stat -f '%Lp' "${MOUNT_SCRIPT_DEST}"
     [ "$status" -eq 0 ]
     [ "$output" = "755" ]
 }


### PR DESCRIPTION
## Summary
- Implements Story 11.1-002: bundles a NAS directory into a checksummed `tar.zst` archive with a SHA256 manifest and compressed file listing.
- Refuses to run when staging free space is below the source size and refuses to silently overwrite an existing bundle.
- Coverage gate: extended `tests/nas_archive.bats` with hermetic tests for the bundle happy path (tar stubbed — BSD tar on the macOS test host doesn't understand GNU tar's `-I` compress-program syntax), the `du`/`df` failure branches, and the free-space boundary case. All die/exit paths and the full `cmd_bundle` body are now exercised (11 → 15 tests). README's bats headline counts synced.

Closes #409

## Test plan
- [x] `bats tests/nas_archive.bats` — 15/15 passing
- [x] `bash tests/run-safe-suite.sh` — 299/299 passing (full safe gate)
- [x] `shellcheck scripts/nas-archive.sh` — clean (pre-existing info-level note only)