### PR TITLE
feat(darwin): add gitlab-runner to power profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,447 test cases (46 BATS files, 299 in the active gate) |
+| **Tests** | 1,448 test cases (46 BATS files, 300 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 35 casks (19 on AI-Assistant), 7 brews, 8 MAS, 50+ Nix |

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -192,6 +192,9 @@
     ++ lib.optionals isPowerProfile [
       go # Go programming language toolchain
       gopls # Go language server
+
+      # CI Tooling
+      gitlab-runner # GitLab CI runner - register/run manually, no launchd service
     ]
     ++ [
       # Cloud CLI Tools

--- a/tests/darwin_system_packages.bats
+++ b/tests/darwin_system_packages.bats
@@ -40,3 +40,11 @@ common_package_lines() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"bun"* ]]
 }
+
+@test "gitlab-runner ships only with the Power profile" {
+    run bash -c "sed -n '/lib.optionals isPowerProfile \[/,/^[[:space:]]*\]/p' '$DARWIN_CONFIG' | rg '^[[:space:]]+gitlab-runner([[:space:]]|#)'"
+    [ "$status" -eq 0 ]
+
+    run common_package_lines gitlab-runner
+    [ "$output" = "" ]
+}


### PR DESCRIPTION
Adds `gitlab-runner` (nixpkgs 19.1.1) to the Power-profile-only system package block in `darwin/configuration.nix`.

- TDD: new bats test asserts the package sits inside the `isPowerProfile` block and is absent from the shared package set (verified red → green)
- Registration/service deliberately manual — `gitlab-runner register` needs stateful tokens that don't belong in the repo; a launchd service can be a follow-up story if wanted
- README headline test counts recomputed per the integrity gate: 1,448 cases / 46 BATS files / 300 in the active gate
- Local gates: `make nix-eval` (all 3 profiles) and `make test` (300/300) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)