### PR TITLE
fix(homebrew): move cmux cask to homebrew-core

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -22,7 +22,6 @@ in
 
     # Homebrew taps (repositories)
     taps = [
-      "manaflow-ai/cmux" # cmux terminal - Ghostty-based terminal with vertical tabs for AI coding agents
       "asmvik/formulae" # skhd - simple hotkey daemon for macOS
     ];
 
@@ -65,7 +64,10 @@ in
     casks = [
       # === Core Apps (all profiles) ===
       "ghostty" # Modern GPU-accelerated terminal (Phase 5 validation test app)
-      "manaflow-ai/cmux/cmux" # cmux - Ghostty-based terminal with vertical tabs and notifications for AI coding agents
+      # cmux moved from the manaflow-ai/cmux tap into homebrew-core (2026-08).
+      # If the first rebuild after this change fails to resolve the cask, run:
+      #   brew uninstall --cask cmux && brew untap manaflow-ai/cmux && brew update && brew install --cask cmux
+      "cmux" # cmux - Ghostty-based terminal with vertical tabs and notifications for AI coding agents
 
       # AI & LLM Tools (Story 02.1-001, 02.1-002)
       "claude" # Claude Desktop - Anthropic's AI assistant


### PR DESCRIPTION
cmux migrated upstream from the `manaflow-ai/cmux` tap into homebrew-core ([manaflow-ai/cmux#3 comment](https://github.com/manaflow-ai/cmux/pull/3)). This drops the tap and installs the core cask.

- Token unchanged (`cmux`) — the installed app carries over; `cleanup = "zap"` untaps the legacy repo on next rebuild
- Migration fallback documented inline: `brew uninstall --cask cmux && brew untap manaflow-ai/cmux && brew update && brew install --cask cmux`
- ⚠️ Core cask declares `auto_updates true` — cmux now self-updates, outside the rebuild/update flow; check in-app settings for a disable toggle (repo constraint: no auto-updates)
- Verified: `brew info --cask cmux` resolves 0.64.20 from core; `make nix-eval` green on all 3 profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)