### PR TITLE
feat(homebrew): add xcode to power profile via mas

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,448 test cases (46 BATS files, 300 in the active gate) |
+| **Tests** | 1,449 test cases (46 BATS files, 301 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 35 casks (19 on AI-Assistant), 7 brews, 8 MAS, 50+ Nix |

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -173,14 +173,22 @@ in
     #   mas install 302584613   # Kindle
     #   mas install 890031187   # Marked 2
     #   mas install 310633997   # WhatsApp
-    masApps = lib.mkIf (userConfig.enableMasApps or false) {
-      "1Password for Safari" = 1569813296; # Safari password manager extension
-      "Perplexity" = 6714467650; # AI search assistant
-      "Kindle" = 302584613; # Ebook reader
-      "Marked 2" = 890031187; # Markdown preview
-      "WhatsApp" = 310633997; # Messaging app
-      "reMarkable desktop" = 1276493162; # reMarkable tablet sync and screen share
-    };
+    masApps = lib.mkIf (userConfig.enableMasApps or false) (
+      {
+        "1Password for Safari" = 1569813296; # Safari password manager extension
+        "Perplexity" = 6714467650; # AI search assistant
+        "Kindle" = 302584613; # Ebook reader
+        "Marked 2" = 890031187; # Markdown preview
+        "WhatsApp" = 310633997; # Messaging app
+        "reMarkable desktop" = 1276493162; # reMarkable tablet sync and screen share
+      }
+      # Power-only: full Xcode IDE (~8GB download, ~40GB installed).
+      # First install requires the Apple ID to have "gotten" Xcode once in the
+      # App Store; after install run `sudo xcodebuild -license accept`.
+      // lib.optionalAttrs (profileName == "power") {
+        "Xcode" = 497799835; # Apple IDE - simulators, Instruments, SDKs
+      }
+    );
   };
 
   # Environment variable to prevent Homebrew auto-updates

--- a/tests/darwin_system_packages.bats
+++ b/tests/darwin_system_packages.bats
@@ -41,6 +41,14 @@ common_package_lines() {
     [[ "$output" == *"bun"* ]]
 }
 
+@test "Xcode ships via mas only on the Power profile" {
+    run bash -c "sed -n '/optionalAttrs (profileName == \"power\")/,/}/p' '$HOMEBREW_CONFIG' | rg '\"Xcode\" = 497799835'"
+    [ "$status" -eq 0 ]
+
+    run bash -c "sed -n '/masApps = /,/optionalAttrs/p' '$HOMEBREW_CONFIG' | rg '\"Xcode\"'"
+    [ "$status" -eq 1 ]
+}
+
 @test "gitlab-runner ships only with the Power profile" {
     run bash -c "sed -n '/lib.optionals isPowerProfile \[/,/^[[:space:]]*\]/p' '$DARWIN_CONFIG' | rg '^[[:space:]]+gitlab-runner([[:space:]]|#)'"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Adds the full Xcode IDE (mas 497799835) to the Power profile's masApps via a profile-aware `optionalAttrs` merge — Standard and AI-Assistant profiles are unaffected.

- TDD: bats test asserts Xcode sits in the Power-only block and not the shared masApps set (verified red → green)
- Inline docs: App Store sign-in prerequisite, ~8GB download / ~40GB installed, `sudo xcodebuild -license accept` post-install
- README headline test counts recomputed: 1,449 cases / 46 BATS files / 301 in the active gate
- Gates: `make nix-eval` (3 profiles) and `make test` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)