### PR TITLE
feat(ai): route opencode to a local ollama coding model on power

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,9 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 **AI & LLM Tools**:
 - Claude Desktop, Claude Code CLI (from `claude-code-nix` flake)
 - ChatGPT, Codex CLI (OpenAI's terminal coding agent)
-- OpenCode and Qwen Code (open source AI coding agents for the terminal)
+- OpenCode and Qwen Code (open source AI coding agents for the terminal). On Power, OpenCode defaults to the **local** `qwen3.6-coding:opencode` model over Ollama — no cloud round-trip
 - Perplexity (MAS)
-- Ollama (Power: `gemma4:e4b` + `gemma4:26b` + `nomic-embed-text`; Standard: `ministral-3:14b` + `nomic-embed-text`; AI-Assistant: `nomic-embed-text`)
+- Ollama (Power: `gemma4:e4b` + `gemma4:26b` + `qwen3.6:35b-a3b-coding-nvfp4` + `nomic-embed-text`; Standard: `ministral-3:14b` + `nomic-embed-text`; AI-Assistant: `nomic-embed-text`)
 - MLX-LM 0.21.0 (Apple Silicon, isolated uv environment at `~/.local/share/mlx-lm/venv`)
 - **Privacy Filter** — on-device PII redaction (MLX port of OpenAI's open-weight Privacy Filter via OpenMed). Always-on LaunchAgent on `127.0.0.1:7790`; BF16 variant on Power, 8-bit on Standard / AI-Assistant. Workflow: `pbcopy` → `redact-clip` → paste into Claude/ChatGPT (Epic-09).
 
@@ -262,7 +262,7 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 |---------|-------------|----------|-------|
 | **Target** | Older MacBook (AI) | MacBook Air | MacBook Pro M3 Max |
 | **Casks** | 17 (core only) | 32 | 32 |
-| **Ollama Models** | 1 (embeddings) | 2 (~9GB) | 3 (~19GB) |
+| **Ollama Models** | 1 (embeddings) | 2 (~9GB) | 4 (~41GB, incl. local coding model) |
 | **Docker Desktop** | No | Yes | Yes |
 | **LSPs** | No | Yes | Yes |
 | **Office/Video Conf** | No | Yes | Yes |
@@ -484,7 +484,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,449 test cases (46 BATS files, 301 in the active gate) |
+| **Tests** | 1,453 test cases (46 BATS files, 305 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 35 casks (19 on AI-Assistant), 7 brews, 8 MAS, 50+ Nix |

--- a/SHA256SUMS
+++ b/SHA256SUMS
@@ -1,3 +1,3 @@
-b7b140a6cf392e298cf04a865d96baa27b71cfed9ee944b1312581e96b82b592  bootstrap-dist.sh
+2c9d7fade9cc0fb8ff3365cb2da4772d2d53aa7c347dc5d490809bfdf387fa60  bootstrap-dist.sh
 a5ff8c9b96f0e94dac9941e28ecbba84ab0ff7bfaf8ec88be4e2c6f837510777  setup.sh
 2ad2104365e20fd6e0d8a1de0ae5dac90898b9a006eac0bba1730236a8cb5f01  user-config.template.nix

--- a/bootstrap-dist.sh
+++ b/bootstrap-dist.sh
@@ -4483,7 +4483,7 @@ display_rebuild_success_message() {
     if [[ "${INSTALL_PROFILE}" == "power" ]]; then
         log_info "3. Verify Ollama models (Power profile):"
         log_info "   ollama list"
-        log_info "   Expected: gemma4:e4b, gemma4:26b, nomic-embed-text"
+        log_info "   Expected: gemma4:e4b, gemma4:26b, qwen3.6:35b-a3b-coding-nvfp4, nomic-embed-text"
         echo ""
     fi
 
@@ -4767,7 +4767,7 @@ display_next_steps() {
     if [[ "${INSTALL_PROFILE:-standard}" == "power" ]]; then
         echo "  3. Verify Ollama models (Power profile):"
         echo "     ollama list"
-        echo "     Expected: gemma4:e4b, gemma4:26b, nomic-embed-text"
+        echo "     Expected: gemma4:e4b, gemma4:26b, qwen3.6:35b-a3b-coding-nvfp4, nomic-embed-text"
         echo ""
     fi
 

--- a/config/ollama/qwen3.6-coding.Modelfile
+++ b/config/ollama/qwen3.6-coding.Modelfile
@@ -1,0 +1,23 @@
+# ABOUTME: Derived Ollama model pinning Qwen3.6's recommended sampling parameters for agentic coding
+# ABOUTME: Carries top_k/min_p/repeat_penalty, which Ollama's OpenAI-compatible endpoint cannot express
+#
+# Parameters follow Qwen's published recommendations for the Qwen3.6 family
+# (temperature 0.6, top_p 0.95, top_k 20, min_p 0).
+#
+# repeat_penalty 1.0 is the one that matters most here: Ollama defaults to 1.1,
+# which penalises the legitimate repetition that source code is full of
+# (closing braces, repeated identifiers, boilerplate) and degrades codegen.
+#
+# num_ctx 48000 matches the reference llama-server deployment. It is baked in
+# rather than left to OLLAMA_CONTEXT_LENGTH so the window travels with the model
+# regardless of which client loads it.
+
+FROM qwen3.6:35b-a3b-coding-nvfp4
+
+PARAMETER num_ctx 48000
+PARAMETER temperature 0.6
+PARAMETER top_p 0.95
+PARAMETER top_k 20
+PARAMETER min_p 0.0
+PARAMETER repeat_penalty 1.0
+PARAMETER presence_penalty 0.0

--- a/darwin/maintenance.nix
+++ b/darwin/maintenance.nix
@@ -38,6 +38,13 @@ let
       else
         "2m"
     );
+  # CONTEXT_LENGTH: agentic coding tools (OpenCode) need a large window for
+  # repository-level reasoning; Ollama's 4K default truncates tool call chains.
+  # Power only — a 64K window costs KV-cache memory the smaller profiles can't
+  # spare. Override with userConfig.ollamaContextLength.
+  ollamaContextLength =
+    userConfig.ollamaContextLength or (if profileName == "power" then "48000" else "8192");
+
   enableOllamaServeAgent = userConfig.enableOllamaServeAgent or false;
 
   # Standard PATH for scheduled LaunchAgents (includes per-user Nix profile)
@@ -567,6 +574,7 @@ in
         OLLAMA_MAX_LOADED_MODELS = ollamaMaxLoadedModels;
         OLLAMA_NUM_PARALLEL = ollamaNumParallel;
         OLLAMA_KEEP_ALIVE = ollamaKeepAlive;
+        OLLAMA_CONTEXT_LENGTH = ollamaContextLength;
         PATH = "/opt/homebrew/bin:/run/current-system/sw/bin:/usr/bin:/bin";
       };
       command = ''

--- a/docs/apps/ai/ai-llm-tools.md
+++ b/docs/apps/ai/ai-llm-tools.md
@@ -150,6 +150,50 @@ curl http://localhost:11434/api/version
 
 ---
 
+## OpenCode → Local Ollama Model (Power profile)
+
+**Status**: On the Power profile, OpenCode defaults to a local model served by Ollama — coding sessions never leave the machine.
+
+**How it is wired**:
+- `home-manager/modules/claude-code.nix` writes an `ollama` provider into `~/.config/opencode/opencode.json`, using `@ai-sdk/openai-compatible` against `http://127.0.0.1:11434/v1` (loopback only, matching the daemon's bind)
+- The default model is `ollama/qwen3.6-coding:opencode` — set **only** on Power. Standard and AI-Assistant get the provider definition but keep their own default, since the 21GB model needs the M3 Max's 48GB of unified memory
+- Do not hand-edit `~/.config/opencode/opencode.json`; activation rewrites it on every rebuild
+
+**Why a derived model** (`config/ollama/qwen3.6-coding.Modelfile`):
+
+Qwen publishes recommended sampling parameters for the Qwen3.6 family, but Ollama's
+OpenAI-compatible endpoint can only express `temperature` and `top_p`. The remaining
+parameters must be baked into a model of their own, which the Power activation builds
+with `ollama create` after the pulls:
+
+| Parameter | Value | Why |
+|-----------|-------|-----|
+| `repeat_penalty` | 1.0 | **The important one.** Ollama defaults to 1.1, penalising the repetition source code is made of (closing braces, repeated identifiers, boilerplate) |
+| `top_k` | 20 | Qwen3.6 recommendation (Ollama default is 40) |
+| `min_p` | 0.0 | Disabled, per Qwen |
+| `num_ctx` | 48000 | Repository-level reasoning; Ollama's default truncates tool-call chains |
+| `temperature` / `top_p` | 0.6 / 0.95 | Qwen recommendation — **also** pinned in `opencode.json`, because absent explicit config OpenCode sends its own Qwen default of 0.55, which would override the model's own value |
+
+`ollama create` reuses the base model's blobs, so the derived model costs a manifest
+and a small parameter layer — not a second 21GB copy.
+
+**Context window**: `OLLAMA_CONTEXT_LENGTH` is set to 48000 on Power (8192 elsewhere) by the
+Ollama LaunchAgent in `darwin/maintenance.nix`. Override with `ollamaContextLength` in
+`user-config.nix`. A larger window grows the KV cache — watch memory pressure if you raise it.
+
+**Verification**:
+```bash
+ollama ps                              # expect 100% GPU, CONTEXT 48000
+ollama show qwen3.6-coding:opencode    # confirm the Parameters block
+opencode                               # no --model flag needed on Power
+```
+
+**Not portable from llama.cpp setups**: speculative decoding (`--spec-type draft-mtp`) is not
+exposed by Ollama, `--tensor-split` is meaningless on unified memory, flash attention is
+automatic, and `--host 0.0.0.0` must **never** be copied — Ollama has no authentication.
+
+---
+
 ## MLX-LM (Apple-Native Runtime)
 
 **Status**: MLX-LM 0.21.0 is provisioned on Apple Silicon by Home Manager in an isolated uv environment at `~/.local/share/mlx-lm/venv`.

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,11 @@
             size = "~16GB";
           }
           {
+            name = "qwen3.6:35b-a3b-coding-nvfp4";
+            desc = "Qwen3.6 35B MoE coding model (3B active) - OpenCode local backend";
+            size = "~22GB";
+          }
+          {
             name = "nomic-embed-text";
             desc = "Text embeddings model";
             size = "~274MB";
@@ -155,8 +160,12 @@
 
       # Generate Ollama model pull activation script for a given profile.
       # Disabled by default so rebuilds do not start Ollama or download models.
+      # derivedModels: [{ name; modelfile; }] built with `ollama create` after the
+      # pulls, while the activation daemon is still up. Used to bake sampling
+      # parameters that the OpenAI-compatible endpoint cannot carry (top_k,
+      # repeat_penalty, min_p) into a model of their own.
       mkOllamaModelScript =
-        profileName: models:
+        profileName: models: derivedModels:
         if userConfig.enableOllamaModelPulls or false then
           let
             modelCount = builtins.length models;
@@ -209,6 +218,19 @@
                   echo "✓ Ollama model $model already installed"
                 fi
               done
+
+              ${builtins.concatStringsSep "\n" (
+                builtins.map (d: ''
+                  # Always re-create: layers are reused, and this is what makes an
+                  # edited Modelfile actually take effect on the next rebuild.
+                  echo "Creating derived Ollama model ${d.name}..."
+                  if /opt/homebrew/bin/ollama create "${d.name}" -f "${d.modelfile}" > /dev/null 2>&1; then
+                    echo "✓ Derived Ollama model ready: ${d.name}"
+                  else
+                    echo "⚠️  Warning: Could not create ${d.name} (is its base model pulled?)"
+                  fi
+                '') derivedModels
+              )}
 
               echo "✓ Ollama model check complete for ${profileName} profile"
 
@@ -360,7 +382,7 @@
             # Use postActivation - one of the hardcoded script names that nix-darwin actually runs
             # See: https://github.com/nix-darwin/nix-darwin/issues/663
             system.activationScripts.postActivation.text = lib.mkAfter (
-              mkOllamaModelScript "Standard" ollamaModels.standard
+              mkOllamaModelScript "Standard" ollamaModels.standard [ ]
             );
           })
         ];
@@ -390,7 +412,12 @@
             # Use postActivation - one of the hardcoded script names that nix-darwin actually runs
             # See: https://github.com/nix-darwin/nix-darwin/issues/663
             system.activationScripts.postActivation.text = lib.mkAfter (
-              mkOllamaModelScript "Power" ollamaModels.power
+              mkOllamaModelScript "Power" ollamaModels.power [
+                {
+                  name = "qwen3.6-coding:opencode";
+                  modelfile = ./config/ollama/qwen3.6-coding.Modelfile;
+                }
+              ]
             );
           })
         ];
@@ -407,7 +434,7 @@
           ({ lib, ... }: {
             # AI-Assistant profile: embeddings-only Ollama model
             system.activationScripts.postActivation.text = lib.mkAfter (
-              mkOllamaModelScript "AI-Assistant" ollamaModels.ai-assistant
+              mkOllamaModelScript "AI-Assistant" ollamaModels.ai-assistant [ ]
             );
           })
         ];

--- a/home-manager/modules/claude-code.nix
+++ b/home-manager/modules/claude-code.nix
@@ -6,11 +6,31 @@
   pkgs,
   lib,
   userConfig,
+  profileName,
   findRepoRoot,
   mcp-servers-nix,
   ...
 }:
 let
+  # OpenCode → local Ollama (Story: local-first coding agent).
+  # Ollama binds loopback only (darwin/maintenance.nix ollamaHost), so the
+  # OpenAI-compatible endpoint must stay on 127.0.0.1.
+  ollamaBaseUrl = "http://127.0.0.1:11434/v1";
+
+  # 35B MoE with ~3B active params; ~22GB resident. Only the Power profile
+  # (M3 Max, 48GB unified) has the headroom, so only it gets the default.
+  # This is the derived model built by config/ollama/qwen3.6-coding.Modelfile,
+  # not the raw pull — the Modelfile carries top_k/min_p/repeat_penalty, which
+  # cannot be expressed over the OpenAI-compatible endpoint.
+  localCodingModel = "qwen3.6-coding:opencode";
+  opencodeDefaultsLocal = profileName == "power";
+
+  # Qwen3.6's published sampling recommendations. These are repeated here even
+  # though the Modelfile bakes them in: absent explicit config, OpenCode sends
+  # its own Qwen default (temperature 0.55), which overrides the model's own.
+  localCodingTemperature = "0.6";
+  localCodingTopP = "0.95";
+  localCodingContext = "48000";
   # Generate MCP server configuration using mcp-servers-nix.lib.mkConfig
   # This automatically handles package paths and server configuration
   mcpConfig = mcp-servers-nix.lib.mkConfig pkgs {
@@ -475,6 +495,23 @@ in
               ."$schema" = (."$schema" // "https://opencode.ai/config.json")
               | .autoupdate = false
               | .share = "disabled"
+              | .provider.ollama = {
+                  "npm": "@ai-sdk/openai-compatible",
+                  "name": "Ollama (local)",
+                  "options": { "baseURL": "${ollamaBaseUrl}" },
+                  "models": {
+                    "${localCodingModel}": {
+                      "name": "Qwen3.6 35B-A3B coding (local)",
+                      "options": {
+                        "temperature": ${localCodingTemperature},
+                        "top_p": ${localCodingTopP}
+                      },
+                      "limit": { "context": ${localCodingContext}, "output": 16384 }
+                    }
+                  }
+                }${lib.optionalString opencodeDefaultsLocal ''
+
+              | .model = "ollama/${localCodingModel}"''}
             ' "$OPENCODE_CONFIG" > "$OPENCODE_CONFIG_TMP"; then
               $DRY_RUN_CMD mv "$OPENCODE_CONFIG_TMP" "$OPENCODE_CONFIG"
               echo "✓ Disabled OpenCode auto-update and sharing"
@@ -487,7 +524,26 @@ in
     {
       "$schema": "https://opencode.ai/config.json",
       "autoupdate": false,
-      "share": "disabled"
+      "share": "disabled",${lib.optionalString opencodeDefaultsLocal ''
+
+      "model": "ollama/${localCodingModel}",''}
+      "provider": {
+        "ollama": {
+          "npm": "@ai-sdk/openai-compatible",
+          "name": "Ollama (local)",
+          "options": { "baseURL": "${ollamaBaseUrl}" },
+          "models": {
+            "${localCodingModel}": {
+              "name": "Qwen3.6 35B-A3B coding (local)",
+              "options": {
+                "temperature": ${localCodingTemperature},
+                "top_p": ${localCodingTopP}
+              },
+              "limit": { "context": ${localCodingContext}, "output": 16384 }
+            }
+          }
+        }
+      }
     }
     EOF
             $DRY_RUN_CMD mv "$OPENCODE_CONFIG_TMP" "$OPENCODE_CONFIG"

--- a/lib/darwin-rebuild.sh
+++ b/lib/darwin-rebuild.sh
@@ -258,7 +258,7 @@ display_rebuild_success_message() {
     if [[ "${INSTALL_PROFILE}" == "power" ]]; then
         log_info "3. Verify Ollama models (Power profile):"
         log_info "   ollama list"
-        log_info "   Expected: gemma4:e4b, gemma4:26b, nomic-embed-text"
+        log_info "   Expected: gemma4:e4b, gemma4:26b, qwen3.6:35b-a3b-coding-nvfp4, nomic-embed-text"
         echo ""
     fi
 

--- a/lib/summary.sh
+++ b/lib/summary.sh
@@ -190,7 +190,7 @@ display_next_steps() {
     if [[ "${INSTALL_PROFILE:-standard}" == "power" ]]; then
         echo "  3. Verify Ollama models (Power profile):"
         echo "     ollama list"
-        echo "     Expected: gemma4:e4b, gemma4:26b, nomic-embed-text"
+        echo "     Expected: gemma4:e4b, gemma4:26b, qwen3.6:35b-a3b-coding-nvfp4, nomic-embed-text"
         echo ""
     fi
 

--- a/tests/claude_code_module.bats
+++ b/tests/claude_code_module.bats
@@ -126,3 +126,70 @@
     run rg -n 'share = "disabled"' "$module"
     [ "$status" -eq 0 ]
 }
+
+@test "opencode declares the local Ollama provider on the loopback endpoint" {
+    module="${BATS_TEST_DIRNAME}/../home-manager/modules/claude-code.nix"
+
+    # Provider must speak the OpenAI-compatible API against Ollama's loopback bind
+    run rg -n -F '@ai-sdk/openai-compatible' "$module"
+    [ "$status" -eq 0 ]
+
+    run rg -n -F 'http://127.0.0.1:11434/v1' "$module"
+    [ "$status" -eq 0 ]
+
+    # Every baseURL must route through the loopback constant asserted above —
+    # a literal URL here would let a non-loopback endpoint slip in unnoticed.
+    run bash -c "rg -n -o '\"baseURL\": \"http[^\"]*\"' '$module'"
+    [ "$status" -eq 1 ]
+}
+
+@test "opencode defaults to the local coding model only on the Power profile" {
+    module="${BATS_TEST_DIRNAME}/../home-manager/modules/claude-code.nix"
+
+    # Must point at the derived model (Modelfile-built), not the raw pull
+    run rg -n -F 'qwen3.6-coding:opencode' "$module"
+    [ "$status" -eq 0 ]
+
+    # The default-model assignment must be gated behind the power profile
+    run rg -n 'profileName == "power"' "$module"
+    [ "$status" -eq 0 ]
+}
+
+@test "opencode pins Qwen3.6 sampling params instead of inheriting OpenCode's Qwen default" {
+    module="${BATS_TEST_DIRNAME}/../home-manager/modules/claude-code.nix"
+
+    # Absent explicit config OpenCode sends temperature 0.55 for Qwen models,
+    # which would override the Modelfile's baked-in value.
+    run rg -n 'localCodingTemperature = "0.6"' "$module"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'localCodingTopP = "0.95"' "$module"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'localCodingContext = "48000"' "$module"
+    [ "$status" -eq 0 ]
+}
+
+@test "coding Modelfile carries the params the OpenAI-compatible API cannot express" {
+    modelfile="${BATS_TEST_DIRNAME}/../config/ollama/qwen3.6-coding.Modelfile"
+
+    [ -f "$modelfile" ]
+
+    # repeat_penalty must be 1.0 — Ollama defaults to 1.1, which penalises the
+    # legitimate repetition source code is made of.
+    run rg -n '^PARAMETER repeat_penalty 1.0$' "$modelfile"
+    [ "$status" -eq 0 ]
+
+    run rg -n '^PARAMETER top_k 20$' "$modelfile"
+    [ "$status" -eq 0 ]
+
+    run rg -n '^PARAMETER min_p 0.0$' "$modelfile"
+    [ "$status" -eq 0 ]
+
+    run rg -n '^PARAMETER num_ctx 48000$' "$modelfile"
+    [ "$status" -eq 0 ]
+
+    # Must build on the pulled base model, not a stale hardcoded tag
+    run rg -n '^FROM qwen3.6:35b-a3b-coding-nvfp4$' "$modelfile"
+    [ "$status" -eq 0 ]
+}

--- a/tests/ollama_messaging_freshness.bats
+++ b/tests/ollama_messaging_freshness.bats
@@ -13,17 +13,17 @@ setup() {
 }
 
 @test "summary.sh Ollama verification lists current Power profile models" {
-    run rg -n "Expected: gemma4:e4b, gemma4:26b, nomic-embed-text" "$SUMMARY_LIB"
+    run rg -n "Expected: gemma4:e4b, gemma4:26b, qwen3.6:35b-a3b-coding-nvfp4, nomic-embed-text" "$SUMMARY_LIB"
     [ "$status" -eq 0 ]
 }
 
 @test "darwin-rebuild.sh Ollama verification lists current Power profile models" {
-    run rg -n "Expected: gemma4:e4b, gemma4:26b, nomic-embed-text" "$DARWIN_REBUILD_LIB"
+    run rg -n "Expected: gemma4:e4b, gemma4:26b, qwen3.6:35b-a3b-coding-nvfp4, nomic-embed-text" "$DARWIN_REBUILD_LIB"
     [ "$status" -eq 0 ]
 }
 
 @test "bootstrap-dist.sh Ollama verification lists current Power profile models" {
-    run rg -c "Expected: gemma4:e4b, gemma4:26b, nomic-embed-text" "$BOOTSTRAP_DIST"
+    run rg -c "Expected: gemma4:e4b, gemma4:26b, qwen3.6:35b-a3b-coding-nvfp4, nomic-embed-text" "$BOOTSTRAP_DIST"
     [ "$status" -eq 0 ]
     # Both the summary and darwin-rebuild call sites are concatenated into the dist.
     [ "$output" -eq 2 ]


### PR DESCRIPTION
OpenCode now defaults to a **local** model on the Power profile — coding sessions never leave the machine.

## What
- `ollama` provider in `opencode.json` (`@ai-sdk/openai-compatible` → `http://127.0.0.1:11434/v1`, loopback only)
- Default model `ollama/qwen3.6-coding:opencode`, **Power-gated** — the 21GB model needs the M3 Max's 48GB unified memory
- `qwen3.6:35b-a3b-coding-nvfp4` added to `ollamaModels.power`; `OLLAMA_CONTEXT_LENGTH=48000` on Power (overridable via `userConfig.ollamaContextLength`)

## Why a derived Modelfile
Ollama's OpenAI-compatible endpoint can only carry `temperature` and `top_p`. Qwen3.6's other recommended parameters are baked into a derived model built by the Power activation (`ollama create` reuses blobs — a manifest, not a second 21GB copy):

| Param | Value | Why |
|---|---|---|
| `repeat_penalty` | 1.0 | Ollama defaults to **1.1**, penalising the repetition source code is made of |
| `top_k` | 20 | Qwen recommendation (default 40) |
| `min_p` / `num_ctx` | 0.0 / 48000 | Per Qwen; 48K for repo-level reasoning |

`temperature`/`top_p` are *also* pinned in `opencode.json`: absent explicit config, OpenCode sends its own Qwen default of **0.55**, overriding the model's own value.

## Deliberately not copied from the reference llama-server setup
`--host 0.0.0.0` (Ollama has no authentication — daemon stays loopback), `--tensor-split` (meaningless on unified memory), speculative decoding (not exposed by Ollama), `-fa on` (automatic).

## Verified on hardware
`ollama ps` → **100% GPU**; `ollama show qwen3.6-coding:opencode` → all 7 parameters confirmed. A guard test caught model-list drift, forcing the bootstrap messaging, `bootstrap-dist.sh` and `SHA256SUMS` to be regenerated.

Docs: README package/profile tables + new section in `docs/apps/ai/ai-llm-tools.md`.
Gates: `make test` 305/305, `make nix-eval` all 3 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)