### PR TITLE
feat(darwin): add jdk to power profile (+ fix nix-eval gate hole)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ nix-eval:
 	NIX_INSTALL_CI=1 nix flake show --impure >/dev/null
 	@for profile in standard power ai-assistant; do \
 		echo "Evaluating $$profile system derivation"; \
-		NIX_INSTALL_CI=1 nix eval --impure --raw "path:.#darwinConfigurations.$$profile.system.drvPath" >/dev/null; \
+		NIX_INSTALL_CI=1 nix eval --impure --raw "path:.#darwinConfigurations.$$profile.system.drvPath" >/dev/null || exit 1; \
 	done
 	git diff --exit-code -- flake.lock
 

--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 - Git + Git LFS + GitHub CLI (`gh`)
 - Node.js (for npx/npm tooling) + Bun runtime and package manager
 - Go + `gopls` **[Power]**
+- JDK (LTS, Zulu 21) with `JAVA_HOME` exported **[Power]**
 - Language servers (pyright, typescript, bash, yaml, etc.)
 
 **Hotkeys**:
@@ -484,7 +485,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,453 test cases (46 BATS files, 305 in the active gate) |
+| **Tests** | 1,455 test cases (46 BATS files, 307 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 35 casks (19 on AI-Assistant), 7 brews, 8 MAS, 50+ Nix |

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -193,6 +193,11 @@
       go # Go programming language toolchain
       gopls # Go language server
 
+      # Java (Power profile only)
+      # nixpkgs `jdk` tracks the current LTS — Zulu 21 on Darwin today. Pin to
+      # jdk17/jdk21 here if a project needs a specific major version.
+      jdk # Java Development Kit (LTS)
+
       # CI Tooling
       gitlab-runner # GitLab CI runner - register/run manually, no launchd service
     ]
@@ -218,6 +223,13 @@
       actionlint # GitHub Actions workflow linter
       gitleaks # Secret detection in git repos (pre-commit + CI)
     ];
+
+  # JAVA_HOME for the Power profile's JDK. A JDK on PATH alone half-works:
+  # `java` runs, but build tools and IDEs that resolve the toolchain by env var
+  # do not. pkgs.jdk.home points at the macOS bundle's Contents/Home.
+  environment.variables = lib.mkIf isPowerProfile {
+    JAVA_HOME = "${pkgs.jdk.home}";
+  };
 
   # Application Management & System Configuration
   system = {

--- a/tests/darwin_system_packages.bats
+++ b/tests/darwin_system_packages.bats
@@ -49,6 +49,19 @@ common_package_lines() {
     [ "$status" -eq 1 ]
 }
 
+@test "the JDK ships only with the Power profile, with JAVA_HOME set" {
+    run bash -c "sed -n '/lib.optionals isPowerProfile \[/,/^[[:space:]]*\]/p' '$DARWIN_CONFIG' | rg '^[[:space:]]+jdk([[:space:]]|#)'"
+    [ "$status" -eq 0 ]
+
+    run common_package_lines jdk
+    [ "$output" = "" ]
+
+    # A JDK on PATH without JAVA_HOME half-works: java runs, but Maven/Gradle
+    # and IDE integrations that resolve the toolchain by env var do not.
+    run rg -n 'JAVA_HOME' "$DARWIN_CONFIG"
+    [ "$status" -eq 0 ]
+}
+
 @test "gitlab-runner ships only with the Power profile" {
     run bash -c "sed -n '/lib.optionals isPowerProfile \[/,/^[[:space:]]*\]/p' '$DARWIN_CONFIG' | rg '^[[:space:]]+gitlab-runner([[:space:]]|#)'"
     [ "$status" -eq 0 ]

--- a/tests/rebuild_regressions.bats
+++ b/tests/rebuild_regressions.bats
@@ -160,6 +160,15 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "nix-eval fails the build when any single profile fails to evaluate" {
+    # Without an explicit exit, the shell for-loop returns the status of its LAST
+    # iteration, so a broken Standard or Power profile passed both `make nix-eval`
+    # and the Validate Nix Flake CI job as long as ai-assistant still evaluated.
+    # Observed 2026-08-04: a type error in the Power profile evaluated to rc=0.
+    run rg -n 'darwinConfigurations\.\$\$profile\.system\.drvPath.*\|\| exit 1' "$MAKEFILE"
+    [ "$status" -eq 0 ]
+}
+
 @test "direnv Zsh hook uses the stable Home Manager profile path" {
     run rg -n 'enableZshIntegration = false;' "$PYTHON_MODULE"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Two commits — the CI fix is arguably the more important one.

## fix(ci): nix-eval swallowed per-profile failures
`make nix-eval` looped over the three profiles without checking exit status, so the shell for-loop reported only its **last** iteration. A completely broken Standard or Power profile passed both the local gate and the **Validate Nix Flake** CI job, as long as `ai-assistant` still evaluated.

Found the hard way: a type error in the Power profile (`JAVA_HOME = pkgs.jdk.home` — a derivation, not a string) produced a full evaluation error **and rc=0**. Fixed with `|| exit 1`; regression test added in `tests/rebuild_regressions.bats`.

## feat(darwin): jdk on Power
- `jdk` (nixpkgs current LTS → Zulu 21 on Darwin) added to the `isPowerProfile` block, alongside Go and gitlab-runner
- `JAVA_HOME` exported from `pkgs.jdk.home`, Power only — a JDK on PATH alone half-works, since Maven/Gradle/IDE toolchain detection resolve by env var
- Maven and Gradle deliberately **not** added — separate decisions
- TDD: test asserts Power-block placement, absence from the shared set, and that JAVA_HOME is wired

Gates: `make test` 307/307 zero failures; `make nix-eval` clean on all 3 profiles — and now meaningfully so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)