### PR TITLE
chore(homebrew): remove perplexity + opencode LSP stories

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,6 @@ execution. Branch installs require the explicit `NIX_INSTALL_BRANCH` override.
 3. **Mac App Store apps** (if you skipped during install):
    ```bash
    # Note: mas 4.0+ requires sudo for install commands (auto-prompts)
-   mas install 6714467650  # Perplexity
    mas install 302584613   # Kindle
    mas install 890031187   # Marked 2
    mas install 310633997   # WhatsApp
@@ -185,7 +184,6 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 - Claude Desktop, Claude Code CLI (from `claude-code-nix` flake)
 - ChatGPT, Codex CLI (OpenAI's terminal coding agent)
 - OpenCode and Qwen Code (open source AI coding agents for the terminal). On Power, OpenCode defaults to the **local** `qwen3.6-coding:opencode` model over Ollama — no cloud round-trip
-- Perplexity (MAS)
 - Ollama (Power: `gemma4:e4b` + `gemma4:26b` + `qwen3.6:35b-a3b-coding-nvfp4` + `nomic-embed-text`; Standard: `ministral-3:14b` + `nomic-embed-text`; AI-Assistant: `nomic-embed-text`)
 - MLX-LM 0.21.0 (Apple Silicon, isolated uv environment at `~/.local/share/mlx-lm/venv`)
 - **Privacy Filter** — on-device PII redaction (MLX port of OpenAI's open-weight Privacy Filter via OpenMed). Always-on LaunchAgent on `127.0.0.1:7790`; BF16 variant on Power, 8-bit on Standard / AI-Assistant. Workflow: `pbcopy` → `redact-clip` → paste into Claude/ChatGPT (Epic-09).
@@ -485,10 +483,10 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,455 test cases (46 BATS files, 307 in the active gate) |
+| **Tests** | 1,459 test cases (47 BATS files, 311 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
-| **Packages** | 35 casks (19 on AI-Assistant), 7 brews, 8 MAS, 50+ Nix |
+| **Packages** | 35 casks (19 on AI-Assistant), 8 brews, 6 MAS (7 on Power with Xcode), 50+ Nix |
 
 **Next**: MacBook Air M4 migration (Phase 11) · Story 08.3-008 (one-day mactop-free validation) · Story 09.1-008 (Privacy Filter verification on hardware)
 

--- a/STORIES.md
+++ b/STORIES.md
@@ -45,13 +45,13 @@ Comprehensive user story organization for the Nix-Darwin MacBook Setup System wi
 | Epic ID | Epic Name | Business Value | Story Count | Total Points | Priority |
 |---------|-----------|----------------|-------------|--------------|----------|
 | Epic-01 | Bootstrap & Installation System | Automated one-command installation | 19 | 113 | Must Have |
-| Epic-02 | Application Installation & Configuration | Declarative app management across profiles | 25 | 118 | Must Have |
+| Epic-02 | Application Installation & Configuration | Declarative app management across profiles | 26 | 121 | Must Have |
 | Epic-03 | System Configuration & macOS Preferences | Automated macOS system preferences | 14 | 76 | Must Have |
 | Epic-04 | Development Environment & Shell | Complete dev tooling setup | 19 | 105 | Must Have |
 | Epic-05 | Theming & Visual Consistency | System-wide consistent theming | 7 | 36 | Should Have |
 | Epic-06 | Maintenance & Monitoring | Self-maintaining system with monitoring | 18 | 97 | Must Have |
 | Epic-07 | Documentation & User Experience | Complete user documentation | 8 | 34 | Must Have |
-| Epic-08 | Resource Optimization & Deep Telemetry | Post-v1.0 disk/memory leaks closed and mactop-grade bar telemetry | 23 | 118 | Should Have |
+| Epic-08 | Resource Optimization & Deep Telemetry | Post-v1.0 disk/memory leaks closed and mactop-grade bar telemetry | 24 | 123 | Should Have |
 | Epic-09 | Local PII Redaction (MLX Privacy Filter) | On-device PII scrubbing before text reaches a cloud LLM | 8 committed (+11 proposed) | TBD | Should Have |
 | Epic-10 | Bootstrap Integrity & Security Hardening | Fix broken fresh installs; tag-pinned clone-first bootstrap; P0 security fixes | 13 | 38 | Must Have |
 | Epic-11 | Cloud Archive Tier | B2 offsite archive pipeline (3-2-1) for irreplaceable cold data | 4 | 13 | Must Have |
@@ -107,14 +107,15 @@ Comprehensive user story organization for the Nix-Darwin MacBook Setup System wi
 - **2026-04-22**: Epic-08 22/23 shipped (all P0 + all P2 + 7/8 P1). Only 08.3-008 (mactop retirement validation) outstanding.
 - **2026-05-07**: Epic-09 (Local PII Redaction) added — Feature 09.1 (8 stories) is the only committed scope; Features 09.2/09.3/09.4 (11 stories) are proposed sketches pending a scope decision, so the epic carries no point total yet.
 - **2026-07-28**: Epic-10 (Bootstrap Integrity & Security Hardening) added from the 2026-07-28 full-repo review — opened at 12 stories / 43 points, closed at 13 stories / 38 points after 10.4-004 was added and the estimates were reconciled against the ledger.
+- **2026-08-04**: Epic-02 reopened for Story 02.1-005 (OpenCode LSP diagnostics, 3 pts) and Epic-08 for Story 08.2-006 (local inference memory budget, 5 pts). Both follow the v2.4.0 local-model provider: 02.1-005 enables language-server feedback without OpenCode auto-downloading servers, 08.2-006 owns whether the model, its KV cache, and those servers fit in memory together.
 - **2026-08-02**: Epic-11 (Cloud Archive Tier) added from the 2026-08-02 storage audit — 4 stories / 13 points. Driver: the 186GB LTIMindtree OneDrive final copy exists only on the NAS; B2 chosen over Glacier Deep Archive for restore ergonomics at ≤400GB scale.
 
 ## Project Metrics
-- **Total Stories**: 173 (125 MVP + 23 Epic-08 + 8 Epic-09 committed + 13 Epic-10 + 4 Epic-11)
-- **Total Story Points**: 827 (658 MVP + 118 Epic-08 + 38 Epic-10 + 13 Epic-11; Epic-09 unestimated)
+- **Total Stories**: 175 (125 MVP + 1 Epic-02 follow-up + 24 Epic-08 + 8 Epic-09 committed + 13 Epic-10 + 4 Epic-11)
+- **Total Story Points**: 835 (658 MVP + 3 Epic-02 follow-up + 123 Epic-08 + 38 Epic-10 + 13 Epic-11; Epic-09 unestimated)
 - **Average Story Size**: 5.1 points
-- **Completed Stories**: 166 (96.0%)
-- **Completed Points**: 810 (97.9%)
+- **Completed Stories**: 166 (94.9%)
+- **Completed Points**: 810 (97.0%)
 - **MVP Completion**: 99.2% by stories, 99.5% by points
 - **🎉 MILESTONE**: MacBook Pro M3 Max successfully running Power profile (2025-12-07)
 - **🎉 MILESTONE**: Epic-08 Resource Optimization & Deep Telemetry — 22/23 stories shipped over 18 hours (2026-04-21 to 2026-04-22)

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -169,14 +169,12 @@ in
     # Requires user to be signed into App Store before installation
     #
     # If disabled, install manually after bootstrap:
-    #   mas install 6714467650  # Perplexity
     #   mas install 302584613   # Kindle
     #   mas install 890031187   # Marked 2
     #   mas install 310633997   # WhatsApp
     masApps = lib.mkIf (userConfig.enableMasApps or false) (
       {
         "1Password for Safari" = 1569813296; # Safari password manager extension
-        "Perplexity" = 6714467650; # AI search assistant
         "Kindle" = 302584613; # Ebook reader
         "Marked 2" = 890031187; # Markdown preview
         "WhatsApp" = 310633997; # Messaging app

--- a/darwin/macos-defaults.nix
+++ b/darwin/macos-defaults.nix
@@ -353,7 +353,6 @@
       # AI Tools (core productivity)
       "/Applications/Claude.app"
       "/Applications/ChatGPT.app"
-      "/Applications/Perplexity.app"
       # Development
       "/Applications/Ghostty.app"
       "/Applications/Brave Browser.app"
@@ -574,7 +573,7 @@
   # - [✅] Auto-correct disabled (Story 03.5-001)
 
   # Feature 03.6: Dock Configuration (Complete)
-  # - [✅] Persistent apps configured (Story 03.6-001) - Mail, Claude, Ghostty, WhatsApp, Perplexity, ChatGPT, 1Password, Brave, Settings, NordVPN
+  # - [✅] Persistent apps configured (Story 03.6-001) - Mail, Claude, Ghostty, WhatsApp, ChatGPT, 1Password, Brave, Settings, NordVPN
   # - [✅] Minimize to application icon (Story 03.6-001)
   # - [✅] Auto-hide enabled (Story 03.6-001)
   # - [✅] Fast auto-hide animation (Story 03.6-001)

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -315,7 +315,7 @@ Consistency: 100% (declarative config)
 #### 2. Application Installation
 
 **REQ-APP-001**: AI/LLM Tools
-- Standard + Power: Claude Desktop, ChatGPT Desktop, Perplexity, Ollama
+- Standard + Power: Claude Desktop, ChatGPT Desktop, Ollama
 - Standard: Ollama pull `gpt-oss:20b` only
 - Power: Additional models `qwen2.5-coder:32b`, `llama3.1:70b`, `deepseek-r1:32b`
 - Acceptance: Apps launch, Ollama models available via `ollama list`
@@ -715,7 +715,7 @@ Consistency: 100% (declarative config)
 - 1Password: Preferences → Advanced → Disable auto-update
 - Raycast: Preferences → Advanced → Disable auto-update
 - Ghostty: `auto-update = off` (already in config)
-- Claude Desktop, ChatGPT Desktop, Perplexity: Disable in app preferences if available
+- Claude Desktop, ChatGPT Desktop: Disable in app preferences if available
 - macOS system updates: Manual only (not automated)
 
 **Implementation:**
@@ -1201,7 +1201,6 @@ Consistency: 100% (declarative config)
 | **AI/LLM Tools** | | |
 | Claude Desktop | Homebrew Cask | GUI app |
 | ChatGPT Desktop | Homebrew Cask (chatgpt) | GUI app |
-| Perplexity | Homebrew Cask | GUI app |
 | Ollama | Homebrew (ollama CLI) | Better macOS integration |
 | **Productivity** | | |
 | Raycast | Homebrew Cask | GUI app |
@@ -1435,7 +1434,7 @@ Consistency: 100% (declarative config)
 | **Power-only modules** | None | NAS rsync backup, SMB automount |
 | **Ollama Models** | `ministral-3:14b`, `nomic-embed-text` (~9GB) | `gemma4:e4b`, `gemma4:26b`, `nomic-embed-text` (~19GB) |
 | **Development Tools** | ✅ Same (Python, Podman, Git LFS) | ✅ Same |
-| **AI Apps** | ✅ Same (Claude, ChatGPT, Perplexity) | ✅ Same |
+| **AI Apps** | ✅ Same (Claude, ChatGPT) | ✅ Same |
 | **Browsers** | ✅ Same (Safari, Firefox, Brave) | ✅ Same |
 | **Productivity** | ✅ Same (Raycast, 1Password, etc.) | ✅ Same |
 | **Communication** | ✅ Same (Telegram, WhatsApp) | ✅ Same |

--- a/docs/apps/README.md
+++ b/docs/apps/README.md
@@ -21,12 +21,11 @@ This directory contains step-by-step configuration guides for applications insta
 
 Desktop applications for AI-powered assistance and local language models.
 
-- [AI & LLM Tools Overview](ai/ai-llm-tools.md) - Claude Desktop, ChatGPT Desktop, Perplexity, Ollama, MLX-LM, Privacy Filter
+- [AI & LLM Tools Overview](ai/ai-llm-tools.md) - Claude Desktop, ChatGPT Desktop, Ollama, MLX-LM, Privacy Filter
 
 **Individual Apps Covered**:
 - Claude Desktop (Homebrew cask)
 - ChatGPT Desktop (Homebrew cask)
-- Perplexity (Mac App Store)
 - Ollama CLI (Homebrew formula)
 - MLX-LM (Apple-native, uv-managed Python environment)
 - Privacy Filter (uv-managed Python/MLX service)
@@ -118,7 +117,7 @@ docs/apps/
 ├── README.md                           # This file - Master index
 ├── mac-app-store-requirements.md       # Prerequisites for mas installations
 ├── ai/
-│   └── ai-llm-tools.md                 # 4 AI tools (Claude, ChatGPT, Perplexity, Ollama)
+│   └── ai-llm-tools.md                 # AI tools (Claude, ChatGPT, Ollama, MLX-LM, Privacy Filter)
 ├── dev/
 │   ├── zed-editor.md                   # Zed configuration
 │   ├── ghostty-terminal.md             # Terminal configuration

--- a/docs/apps/ai/ai-llm-tools.md
+++ b/docs/apps/ai/ai-llm-tools.md
@@ -1,5 +1,5 @@
 # ABOUTME: AI and LLM desktop applications configuration guide
-# ABOUTME: Covers Claude Desktop, ChatGPT Desktop, Perplexity, Ollama (CLI), and Open WebUI
+# ABOUTME: Covers Claude Desktop, ChatGPT Desktop, Ollama (CLI), OpenCode's local model, and Open WebUI
 
 # AI & LLM Tools
 
@@ -55,64 +55,6 @@
 
 ---
 
-## Perplexity
-
-**Status**: Installed via **Mac App Store** (App ID: 6714467650) - Story 02.1-001
-
-**⚠️ CRITICAL - FRESH MACHINE REQUIREMENT**: On brand new Macs, Perplexity MUST be installed manually via App Store GUI first, then darwin-rebuild can manage it.
-
-**First-Time Installation on Fresh Mac** (Issue #25, #26):
-1. Open **App Store** app
-2. Search for **"Perplexity"** or navigate to your Purchased apps
-3. Click the **cloud download icon** (☁️↓) to install manually
-4. Wait for installation to complete
-5. **Then** run darwin-rebuild (mas CLI will work after first manual install)
-
-**Why Manual Install Required**:
-- Fresh macOS installations require the first App Store install to be manual (GUI-based)
-- This initializes Mac App Store services and permissions
-- The `mas` CLI tool (used by nix-darwin) cannot install apps on completely fresh systems
-- Error: `Code=201 "The installation could not be started"`
-- After one manual install, `mas` works normally for all subsequent installs
-
-**⚠️ PREREQUISITE**: You must be signed into the Mac App Store BEFORE running darwin-rebuild (see [Mac App Store Requirements](../mac-app-store-requirements.md))
-
-**Important Notes**:
-- Perplexity is distributed via Mac App Store, not Homebrew
-- Released as native macOS app on October 24, 2024
-- **Installation requires**: Mac App Store sign-in (mas authentication)
-- **Fresh machines**: Manual GUI install required first (see above)
-- Auto-updates managed by App Store preferences (not app-level settings)
-
-**First Launch**:
-1. Launch Perplexity from Spotlight or Raycast
-2. Sign in with your Perplexity account (optional for basic features)
-3. Complete the onboarding flow
-4. Free tier: 5 Pro Searches per day
-5. Pro tier: $20/month for 600 Pro Searches daily
-
-**Auto-Update Configuration**:
-- **Managed by**: macOS App Store (system-level)
-- **To disable App Store auto-updates**:
-  1. Open **System Settings** → **App Store**
-  2. Uncheck **Automatic Updates** for all apps
-  3. Or manage per-app: Right-click app in Launchpad → **Options** → **Turn Off Automatic Updates**
-- **Note**: App Store updates are system-wide, not per-app for Mac App Store installations
-
-**Testing**:
-- [ ] Launch Perplexity successfully (installed from App Store)
-- [ ] Sign-in flow completes (optional, not required)
-- [ ] Accessible from Spotlight/Raycast
-- [ ] Verify App Store update settings are disabled system-wide
-
-**Features**:
-- Pro Search with advanced AI models (GPT-4, Claude 3)
-- Voice input for hands-free queries
-- Threaded conversations with context
-- Library feature for archived searches
-- All responses include cited sources
-
----
 
 ## Ollama (CLI + Optional LaunchAgent)
 

--- a/docs/apps/mac-app-store-requirements.md
+++ b/docs/apps/mac-app-store-requirements.md
@@ -15,7 +15,7 @@
 4. Complete authentication
 
 **Why this is required:**
-- Some apps (like Perplexity) are installed via Mac App Store using `mas` (Mac App Store CLI)
+- Some apps (like Kindle and WhatsApp) are installed via Mac App Store using `mas` (Mac App Store CLI)
 - `mas` cannot install apps unless you are signed into the App Store
 - darwin-rebuild will fail if trying to install mas apps without authentication
 
@@ -44,7 +44,7 @@ mas account
 
 **Solution - Manual First Install**:
 1. Open **App Store** app
-2. Search for any Mac App Store app (e.g., "Perplexity")
+2. Search for any Mac App Store app (e.g., "Kindle")
 3. Click the **cloud download icon** (☁️↓) or **GET** button
 4. Wait for installation to complete
 5. **Then** re-run bootstrap or darwin-rebuild
@@ -56,7 +56,6 @@ mas account
 - This is a macOS limitation, not a nix-darwin bug
 
 **Apps Requiring This Workaround**:
-- Perplexity (6714467650)
 - Kindle (302584613) - if added to masApps
 - WhatsApp (if using mas instead of Homebrew)
 - Any other Mac App Store apps in your masApps list

--- a/stories/epic-02-application-installation.md
+++ b/stories/epic-02-application-installation.md
@@ -14,11 +14,11 @@
 - Email accounts (1 Gmail, 4 Gandi.net) configured and functional in macOS Mail.app
 
 ## Epic Scope
-**Total Stories**: 25
-**Total Story Points**: 118
-**Completed Stories**: 25 (100%)
-**Completed Points**: 118 (100%)
-**MVP Stories**: 25 (100% of epic)
+**Total Stories**: 26 (25 MVP shipped + 1 post-v1.0 follow-up)
+**Total Story Points**: 121 (118 MVP shipped + 3 follow-up)
+**Completed Stories**: 25 of 26 (96%)
+**Completed Points**: 118 of 121 (98%)
+**MVP Stories**: 25 (100% of MVP scope complete)
 **Priority Level**: Must Have
 **Target Release**: Phase 2-3 (Week 2-3)
 
@@ -27,9 +27,10 @@
 
 > **Note**: Detailed story implementations have been moved to feature-specific files in `stories/features/` for better maintainability. See links below.
 
-### Feature 02.1: AI & LLM Tools Installation ✅ COMPLETE
+### Feature 02.1: AI & LLM Tools Installation 🟢
 **Feature Description**: Install and configure AI/LLM applications and models
-**Story Count**: 4 (4/4 complete) | **Story Points**: 16 (16/16 complete) | **Priority**: High | **Complexity**: Medium
+**Story Count**: 5 (4/5 complete) | **Story Points**: 19 (16/19 complete) | **Priority**: High | **Complexity**: Medium
+**Note**: Reopened 2026-08-04 for Story 02.1-005 (OpenCode LSP diagnostics), a post-v1.0 follow-up to the local-model provider shipped in v2.4.0.
 👉 **[View detailed implementation](features/epic-02-feature-02.1.md)**
 
 ### Feature 02.2: Development Environment Applications ✅ COMPLETE

--- a/stories/epic-08-resource-optimization.md
+++ b/stories/epic-08-resource-optimization.md
@@ -15,12 +15,12 @@
 - FX can retire `mactop` for day-to-day monitoring
 
 ## Epic Scope
-**Total Stories**: 23
-**Total Story Points**: 118
-**MVP Stories**: 13 (57% — Features 08.1 and 08.2)
+**Total Stories**: 24
+**Total Story Points**: 123
+**MVP Stories**: 13 (54% — Features 08.1 and 08.2)
 **Priority Level**: Should Have (post-v1.0 enhancement)
 **Target Release**: v1.1.0
-**Status**: 🟢 **22/23 stories shipped** (08.3-008 is acceptance-only, pending one-day mactop-free validation)
+**Status**: 🟢 **22/24 stories shipped** (08.3-008 is acceptance-only, pending one-day mactop-free validation; 08.2-006 added 2026-08-04 for the local-inference memory budget)
 
 ## Features in This Epic
 
@@ -34,8 +34,8 @@
 
 ### Feature 08.2: Memory Pressure Mitigation ✅
 **Feature Description**: Tune Ollama LaunchAgent environment (`OLLAMA_MAX_LOADED_MODELS`, `OLLAMA_KEEP_ALIVE`, `OLLAMA_NUM_PARALLEL`), memory-pressure-triggered model unload, LaunchAgent steady-state audit, swap alerting
-**Story Count**: 5 | **Story Points**: 26 | **Priority**: Must Have (P0) | **Complexity**: Medium
-**Status**: ✅ 5/5 shipped (PRs #260, #264, #265, #271, #272; follow-up fixes #273, #274; architecture snapshot commit 544d6cb)
+**Story Count**: 6 | **Story Points**: 31 | **Priority**: Must Have (P0) | **Complexity**: Medium
+**Status**: 🟢 5/6 shipped (PRs #260, #264, #265, #271, #272; follow-up fixes #273, #274; architecture snapshot commit 544d6cb). Story 08.2-006 (local inference memory budget) added 2026-08-04 — the 21GB coding model, its KV cache, and OpenCode's LSP servers now compete for the same headroom.
 👉 **[View detailed implementation](features/epic-08-feature-08.2.md)**
 
 ### Feature 08.3: SketchyBar Deep Telemetry 🟢

--- a/stories/features/epic-02-feature-02.1.md
+++ b/stories/features/epic-02-feature-02.1.md
@@ -308,3 +308,57 @@
 
 ---
 
+
+##### Story 02.1-005: OpenCode LSP Diagnostics (Declarative, No Auto-Download)
+**User Story**: As FX, I want OpenCode to feed language-server diagnostics back to the local coding model so that it catches the type errors and hallucinated APIs it introduces, without OpenCode downloading language servers behind my back
+
+**Priority**: Should Have
+**Story Points**: 3
+**Sprint**: TBD
+
+**Acceptance Criteria**:
+- **Given** the Power profile is applied and `rebuild` has run
+- **When** OpenCode starts in a repository containing Python, TypeScript, Nix, Go, Bash, or YAML files
+- **Then** the OpenCode status pane no longer reports "LSPs are disabled"
+- **And** diagnostics from the matching language server are available to the agent as feedback
+- **And** every language server used resolves to a Nix-provided binary already on `PATH`
+- **And** `OPENCODE_DISABLE_LSP_DOWNLOAD` is exported, so no language server is fetched at runtime
+- **And** built-in servers whose only install path is a download (terraform, kotlin-ls, lua-ls, php, svelte, clangd, astro) are explicitly `disabled`
+- **And** `~/.local/share/opencode` gains no downloaded language-server binaries after a full session
+- **Given** a fresh `rebuild` on any profile
+- **When** activation rewrites `~/.config/opencode/opencode.json`
+- **Then** the `lsp` block is present and matches the declared configuration (no drift)
+
+**Additional Requirements**:
+- All required servers are already declared in `darwin/configuration.nix`: `pyright`, `typescript-language-server`, `bash-language-server`, `yaml-language-server`, `nixd`, `gopls`
+- The AI-Assistant profile omits the heavier JS/TS server stack (see `darwin/configuration.nix:113`) — the config must degrade gracefully rather than error when a server binary is absent
+- `jdtls` (Java) and `sourcekit-lsp` (Swift) became viable with the JDK (v2.5.0) and Xcode (v2.3.0) additions; enabling them is **out of scope** for this story
+- Do not hand-edit `~/.config/opencode/opencode.json` — activation owns it
+
+**Technical Notes**:
+- Config surface is the OpenCode activation block in `home-manager/modules/claude-code.nix`, which already writes the provider/model config via both a `jq` merge and a heredoc branch — the `lsp` key must be added to **both**
+- `"lsp": true` enables all built-ins; per-server opt-out is `"lsp": { "<name>": { "disabled": true } }`
+- `OPENCODE_DISABLE_LSP_DOWNLOAD` confirmed present in the OpenCode 1.18.10 binary
+- This directly serves the repo's "No Auto-Updates" constraint: OpenCode's built-in table lists servers that "auto-install" and one that fetches "from GitHub releases", which would introduce unversioned binaries invisible to `flake.lock`
+- **Open question (deferred to Epic-08 Story 08.5-001)**: each live LSP server costs a few hundred MB. At the time of writing the Power machine sits at swap 5.65/6.14 GB with a 21GB model and a 48k context resident. The memory budget for local inference plus language servers is tracked separately; if that story lowers the context window, revisit whether all servers should stay enabled.
+
+**Definition of Done**:
+- [ ] `lsp` configuration added to both branches of the OpenCode activation block
+- [ ] `OPENCODE_DISABLE_LSP_DOWNLOAD` exported declaratively
+- [ ] bats coverage: `lsp` present in both branches, download-disable env var set, download-only servers explicitly disabled
+- [ ] `make test` and `make nix-eval` green
+- [ ] Verified on hardware by FX: status pane shows LSPs active, `~/.local/share/opencode` gains no server binaries
+- [ ] `docs/apps/ai/ai-llm-tools.md` OpenCode section documents the LSP behaviour and the no-download guarantee
+
+**Dependencies**:
+- Story 02.1-002 (Ollama installed)
+- OpenCode local-model provider configuration (shipped v2.4.0)
+- Epic-04 language server installations (`pyright`, `nixd`, `gopls`, et al.)
+
+**Risk Level**: Low
+**Risk Mitigation**:
+- Additive configuration; if a server is missing OpenCode simply does not start it
+- Memory impact bounded by the companion Epic-08 story before enabling further servers
+- Rollback is a single `rebuild` away (previous generation restores the old config)
+
+---

--- a/stories/features/epic-08-feature-08.2.md
+++ b/stories/features/epic-08-feature-08.2.md
@@ -274,3 +274,51 @@
 **Risk Level**: Low
 
 ---
+
+##### Story 08.2-006: Local Inference Memory Budget (Model + Context + LSPs)
+**User Story**: As FX, I want a defensible memory budget for local inference so that running the coding model, a 48k context, and language servers together does not push the Power machine into sustained swap
+
+**Priority**: Should Have
+**Story Points**: 5
+**Sprint**: TBD
+
+**Acceptance Criteria**:
+- **Given** the Power machine with `qwen3.6-coding:opencode` resident and an OpenCode session active
+- **When** memory is sampled over a representative working period
+- **Then** the resident cost of each component is recorded: model weights, KV cache at the configured context, and each live LSP server
+- **And** a recommended `ollamaContextLength` is chosen from measurement rather than assumption
+- **And** sustained swap stays below the `SWAP_WARNING_GB` threshold from Story 08.2-005 during normal agentic coding
+- **Given** the recommended context length differs from the shipped 48000
+- **When** the change is applied
+- **Then** `darwin/maintenance.nix` and `config/ollama/qwen3.6-coding.Modelfile` are updated together, since both carry the window
+- **And** the tokens/s baseline is re-measured so the memory/throughput trade-off is explicit
+
+**Additional Requirements**:
+- Baseline captured 2026-08-04 on the M3 Max (48 GB), for comparison rather than as a clean-room reference — it was taken with swap already at 5.65/6.14 GB:
+  - generation ~82–88 tok/s, prefill ~1,416 tok/s at 6.6k tokens, TTFT ~4.7 s
+- Components competing for the same headroom: 21 GB model weights, KV cache scaling with `num_ctx`, one LSP server per active language (a few hundred MB each), plus Docker/Parallels-class workloads
+- The context window is declared in **two** places and must not drift: `ollamaContextLength` in `darwin/maintenance.nix` and `PARAMETER num_ctx` in the Modelfile
+
+**Technical Notes**:
+- Measurement inputs already available: `ollama ps` (resident size, GPU share, context), `/metrics` (`memory.swap_used_gb`, per-process), `sysctl vm.swapusage`, and `audit-launchagents` for steady-state RSS
+- Ollama's API returns exact counters for the throughput half — `eval_count`/`eval_duration` for generation and `prompt_eval_*` for prefill; keep `load_duration` separate so a cold start is not charged to the model
+- If measurement says 48000 is too hungry, 32768 is the natural fallback (it was Ollama's own default here before the change)
+- Related: Story 02.1-005 enables LSP servers; this story owns whether their memory cost is affordable alongside the model
+
+**Definition of Done**:
+- [ ] Per-component memory costs measured and recorded
+- [ ] Context-length recommendation made from data
+- [ ] If changed, both declaration sites updated in one change with a test guarding they agree
+- [ ] Throughput re-baselined after any context change
+- [ ] Finding documented in `docs/apps/ai/ai-llm-tools.md`
+
+**Dependencies**:
+- Story 08.2-005 (swap threshold and `/metrics` flags)
+- Story 02.1-005 (LSP servers enabled — the other half of the budget)
+- OpenCode local-model configuration (shipped v2.4.0)
+
+**Risk Level**: Low
+**Risk Mitigation**:
+- Measurement-only until a change is justified; any context change is one `rebuild` from rollback
+
+---

--- a/tests/retired_perplexity.bats
+++ b/tests/retired_perplexity.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# ABOUTME: Guards retirement of the Perplexity Mac App Store app
+# ABOUTME: Prevents the masApps entry, Dock slot, and documentation from returning
+
+setup() {
+    REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+    HOMEBREW_CONFIG="${REPO_ROOT}/darwin/homebrew.nix"
+    MACOS_DEFAULTS="${REPO_ROOT}/darwin/macos-defaults.nix"
+}
+
+@test "Mac App Store no longer installs Perplexity" {
+    run rg -n -i 'Perplexity|6714467650' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 1 ]
+}
+
+@test "Dock no longer pins Perplexity" {
+    run rg -n -i 'Perplexity' "$MACOS_DEFAULTS"
+    [ "$status" -eq 1 ]
+}
+
+@test "current documentation no longer advertises Perplexity" {
+    run rg -n -i 'perplexity' \
+        "${REPO_ROOT}/README.md" \
+        "${REPO_ROOT}/docs/REQUIREMENTS.md" \
+        "${REPO_ROOT}/docs/apps/README.md" \
+        "${REPO_ROOT}/docs/apps/ai/ai-llm-tools.md" \
+        "${REPO_ROOT}/docs/apps/mac-app-store-requirements.md"
+    [ "$status" -eq 1 ]
+}
+
+@test "retained Mac App Store apps remain declared" {
+    # The retirement must not take the rest of masApps with it
+    run rg -n '"Kindle" = 302584613' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+
+    run rg -n '"WhatsApp" = 310633997' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+}

--- a/tests/run-safe-suite.sh
+++ b/tests/run-safe-suite.sh
@@ -37,6 +37,7 @@ safe_bats_suites=(
     tests/release_monitor.bats
     tests/retired_desktop_utilities.bats
     tests/retired_icloud_sync.bats
+    tests/retired_perplexity.bats
     tests/retired_requirements_integrity_gate.bats
     tests/retired_vscode.bats
     tests/smb_automount_activation.bats


### PR DESCRIPTION
Two unrelated commits, split for a readable history.

## chore(homebrew): remove Perplexity
- `masApps` entry and Dock slot removed
- Purged from **all** current docs — README, REQUIREMENTS, apps/README, mac-app-store-requirements (which used it as its worked example, now Kindle), and the whole `## Perplexity` section of ai-llm-tools.md. This follows the f.lux/GIMP/Arc precedent of removing rather than annotating
- New `tests/retired_perplexity.bats` guard (matching the existing `retired_*.bats` convention), registered in the safe suite: asserts absence from config/Dock/docs **and** that Kindle + WhatsApp survived the edit
- Drive-by: README package line said 7 brews when `pango` made it 8; MAS count corrected to 6 (7 on Power with Xcode)

⚠️ `rebuild` does not uninstall an already-installed MAS app — `/Applications/Perplexity.app` needs removing by hand.

## docs(stories): OpenCode LSP + memory budget
From `/create-story`. **02.1-005** (Epic-02, 3 pts) enables LSP diagnostics as agent feedback while blocking OpenCode's runtime server downloads, preserving the no-auto-update rule. **08.2-006** (Epic-08, 5 pts) owns whether the model, KV cache and LSP servers fit in memory together, with today's tokens/s baseline recorded.

Gates: `make test` 311/311 zero failures; `make nix-eval` clean on all 3 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)