### PR TITLE
fix(docs): remove dead links exposed by the raycast retirement

### DIFF
--- a/docs/apps/browsers/brave.md
+++ b/docs/apps/browsers/brave.md
@@ -237,4 +237,3 @@ Brave Rewards allows earning BAT cryptocurrency for viewing privacy-respecting a
 ## Related Documentation
 
 - [Main Apps Index](../README.md) - Overview of all application documentation
-- [Parent Document](../../app-post-install-configuration.md) - Full application post-install configuration guide

--- a/docs/apps/media/vlc.md
+++ b/docs/apps/media/vlc.md
@@ -275,7 +275,6 @@ VLC provides comprehensive media playback capabilities:
 **Documentation**:
 - VLC Official Site: https://www.videolan.org/vlc/
 - User Guide: https://www.videolan.org/support/
-- Keyboard Shortcuts: https://wiki.videolan.org/Mac_OS_X_shortcuts/
 - Format Support: https://wiki.videolan.org/VLC_Features_Formats/
 
 ---
@@ -283,5 +282,3 @@ VLC provides comprehensive media playback capabilities:
 ## Related Documentation
 
 - [Main Apps Index](../README.md)
-- [GIMP - Image Editor](./gimp.md)
-- [Media Tools Overview](./README.md)

--- a/docs/licensed-apps.md
+++ b/docs/licensed-apps.md
@@ -539,7 +539,7 @@ with full knowledge that updates are no longer managed by `rebuild`.
 After activating licensed apps:
 
 1. **Verify functionality**: Launch each app and confirm sign-in successful
-2. **Configure settings**: See `docs/app-post-install-configuration.md` for detailed setup
+2. **Configure settings**: See the per-app guides under `docs/apps/` for detailed setup
 3. **Test core features**: Ensure licenses unlock the expected features
 4. **Store credentials safely**: Save license keys, Emergency Kits, and recovery codes in secure location
 5. **Set calendar reminders**: Add renewal reminders 30 days before subscription expiration


### PR DESCRIPTION
The **Check Markdown Links** job failed on #422. The dead links were not introduced by that change — the job only scans files changed in a PR, so touching `brave.md` and `vlc.md` pulled them into scope and surfaced rot that predates it:

| Dead link | Why |
|---|---|
| `../../app-post-install-configuration.md` | Split into `docs/apps/` and archived (noted in apps/README) |
| `./gimp.md` | Went with the earlier GIMP retirement |
| `./README.md` (media) | `docs/apps/media/` only contains `vlc.md` |
| `wiki.videolan.org/Mac_OS_X_shortcuts/` | Upstream 404 |

Also replaced a prose reference to the archived parent doc in `licensed-apps.md` with a pointer to `docs/apps/`.

⚠️ Worth knowing: because the job is changed-files-only, other untouched docs may carry similar rot. A full-tree link sweep would be a separate piece of work.

Gates: `make test` 314/314 zero failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)