### PR TITLE
feat(homebrew): add 1password cli to power profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,10 +483,10 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,460 test cases (47 BATS files, 312 in the active gate) |
+| **Tests** | 1,461 test cases (47 BATS files, 313 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
-| **Packages** | 34 casks (18 on AI-Assistant), 8 brews, 6 MAS (7 on Power with Xcode), 50+ Nix |
+| **Packages** | 34 casks (18 on AI-Assistant), 8 brews (9 on Power with 1Password CLI), 6 MAS (7 on Power with Xcode), 50+ Nix |
 
 **Next**: MacBook Air M4 migration (Phase 11) · Story 08.3-008 (one-day mactop-free validation) · Story 09.1-008 (Privacy Filter verification on hardware)
 

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -58,6 +58,14 @@ in
       # Note: yt-dlp broken in nixpkgs (curl-impersonate AppleIDN check fails on macOS 15.3)
       "yt-dlp" # YouTube/video downloader (active fork of youtube-dl)
 
+    ]
+    # === Power profile only ===
+    # 1Password CLI via Homebrew rather than nixpkgs `_1password-cli`. Both ship
+    # 1Password's own signed binary (TeamIdentifier 2BUA8C4S2C), but the brew
+    # formula is the vendor's documented macOS path and is the one verified
+    # working against the desktop app's biometric integration on this fleet.
+    ++ lib.optionals (profileName == "power") [
+      "1password-cli" # `op` - secret injection, vault access, biometric unlock via the 1Password app
     ];
 
     # GUI applications; fonts remain owned by Nix/Stylix.
@@ -189,5 +197,14 @@ in
   };
 
   # Environment variable to prevent Homebrew auto-updates
-  environment.variables.HOMEBREW_NO_AUTO_UPDATE = "1";
+  # OP_BIOMETRIC_UNLOCK_ENABLED lets `op` authorise through the 1Password desktop
+  # app (Touch ID) instead of prompting for a password every session. Power-only,
+  # matching the CLI itself. Still requires the one-time GUI toggle:
+  # 1Password → Settings → Developer → "Integrate with 1Password CLI".
+  environment.variables = {
+    HOMEBREW_NO_AUTO_UPDATE = "1";
+  }
+  // lib.optionalAttrs (profileName == "power") {
+    OP_BIOMETRIC_UNLOCK_ENABLED = "true";
+  };
 }

--- a/tests/darwin_system_packages.bats
+++ b/tests/darwin_system_packages.bats
@@ -49,6 +49,20 @@ common_package_lines() {
     [ "$status" -eq 1 ]
 }
 
+@test "1Password CLI ships via Homebrew on the Power profile only" {
+    # Homebrew, not Nix: FX verified the brew formula works with the desktop
+    # app's biometric integration, and it is 1Password's own documented path.
+    run bash -c "sed -n '/optionals (profileName == \"power\")/,/\]/p' '$HOMEBREW_CONFIG' | rg '\"1password-cli\"'"
+    [ "$status" -eq 0 ]
+
+    # Must not leak into the Nix system package set
+    run rg -n '_1password-cli' "$DARWIN_CONFIG"
+    [ "$status" -eq 1 ]
+
+    run rg -n 'OP_BIOMETRIC_UNLOCK_ENABLED' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+}
+
 @test "the JDK ships only with the Power profile, with JAVA_HOME set" {
     run bash -c "sed -n '/lib.optionals isPowerProfile \[/,/^[[:space:]]*\]/p' '$DARWIN_CONFIG' | rg '^[[:space:]]+jdk([[:space:]]|#)'"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Adds the `op` CLI (secret injection, vault access, biometric unlock) to the Power profile.

## Notes
- `brews` had **no profile gating** (unlike the casks), so this introduces a `lib.optionals (profileName == "power")` block alongside the flat list
- **Homebrew over nixpkgs**: I checked the nixpkgs `_1password-cli` binary and it does retain 1Password's official signature (`TeamIdentifier=2BUA8C4S2C`, hardened runtime) — so both routes work. The brew formula is the vendor's documented macOS path and the one FX verified against the desktop app's biometric integration, so it wins
- `OP_BIOMETRIC_UNLOCK_ENABLED=true`, Power-only, so `op` authorises via Touch ID rather than prompting every session

## Manual step that config cannot cover
**1Password → Settings → Developer → "Integrate with 1Password CLI"** must be toggled once. Without it biometric unlock will not engage regardless of the environment variable. Documented inline.

## Verified
- Evaluated config: `OP_BIOMETRIC_UNLOCK_ENABLED` is `true` on Power and **absent** on Standard
- TDD: test asserts the brew is Power-gated, does not leak into the Nix package set, and the env var is wired (red → green)
- First attempt defined `environment.variables` twice in one module and broke Power evaluation — caught by `make nix-eval`, which returns a proper non-zero exit since the gate fix in v2.5.0. Fixed with `lib.optionalAttrs`

Gates: `make test` 313/313 zero failures; `make nix-eval` clean on all 3 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)