### PR TITLE
fix(homebrew): 1password-cli is a cask now, not a formula

### DIFF
--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -58,14 +58,6 @@ in
       # Note: yt-dlp broken in nixpkgs (curl-impersonate AppleIDN check fails on macOS 15.3)
       "yt-dlp" # YouTube/video downloader (active fork of youtube-dl)
 
-    ]
-    # === Power profile only ===
-    # 1Password CLI via Homebrew rather than nixpkgs `_1password-cli`. Both ship
-    # 1Password's own signed binary (TeamIdentifier 2BUA8C4S2C), but the brew
-    # formula is the vendor's documented macOS path and is the one verified
-    # working against the desktop app's biometric integration on this fleet.
-    ++ lib.optionals (profileName == "power") [
-      "1password-cli" # `op` - secret injection, vault access, biometric unlock via the 1Password app
     ];
 
     # GUI applications; fonts remain owned by Nix/Stylix.
@@ -163,6 +155,15 @@ in
     ++ lib.optionals (profileName == "power") [
       "fluidvoice" # FluidVoice - Local-first voice dictation with on-device speech models
       "qobuz" # Qobuz - Hi-Res music streaming and offline playback
+      # 1Password CLI via Homebrew rather than nixpkgs `_1password-cli`. Both
+      # ship 1Password's own signed binary (TeamIdentifier 2BUA8C4S2C), but
+      # Homebrew is the vendor's documented macOS path and the one verified
+      # working against the desktop app's biometric integration on this fleet.
+      #
+      # A cask, not a formula: upstream retired the `1password-cli` formula, so
+      # `brew bundle` fails the whole rebuild with "No formulae found for
+      # 1password-cli" while it is declared under `brews`.
+      "1password-cli" # `op` - secret injection, vault access, biometric unlock via the 1Password app
     ];
 
     # Global Homebrew options


### PR DESCRIPTION
Upstream Homebrew retired the `1password-cli` **formula**; it exists only as a **cask**. With it still declared under `brews`, `brew bundle` fails and takes the entire `rebuild` down before home-manager activation runs:

```
Installing 1password-cli has failed!
Error: No formulae found for 1password-cli.
`brew bundle` failed! 1 Brewfile dependency failed to install
✗ Failed to rebuild system
```

Moved to the Power-profile `casks` list, keeping the original rationale for preferring Homebrew over nixpkgs `_1password-cli` and recording why it is a cask so nobody moves it back.

`make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)