### PR TITLE
chore(homebrew): replace istat menus with the open-source stats

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ One git repo defines everything. Push a change, rebuild, and all machines stay p
 The stack: **Nix + nix-darwin + Home Manager** for declarative, atomic, rollback-capable configuration — plus an AI-powered release monitor that opens GitHub issues before I even know updates exist.
 
 ![Rebuild in action](./docs/images/rebuild-screenshot.png)
-*A `rebuild` in action — Ghostty terminal with Catppuccin theme, iStat Menus monitoring, and system-wide consistency.*
+*A `rebuild` in action — Ghostty terminal with Catppuccin theme, menubar system monitoring, and system-wide consistency.*
 
 ---
 
@@ -61,7 +61,7 @@ execution. Branch installs require the explicit `NIX_INSTALL_BRANCH` override.
    ```
 4. **Activate licenses** — See [Licensed Apps Guide](./docs/licensed-apps.md):
    - 1Password, NordVPN (sign in)
-   - iStat Menus, Little Snitch (enter license key)
+   - Little Snitch (enter license key)
    - Office 365 (Microsoft account sign-in)
 
 ---
@@ -224,7 +224,7 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 
 **Security**: NordVPN, Tailscale, Little Snitch
 
-**System & Monitoring**: iStat Menus, mactop, Beszel (macmon telemetry backend), Stream Deck **[S/P]**
+**System & Monitoring**: Stats (open source), mactop, Beszel (macmon telemetry backend), Stream Deck **[S/P]**
 
 **Remote Access**: RustDesk **[S/P]**
 

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -108,7 +108,7 @@ in
       "plaud" # Plaud - AI voice recorder and transcription companion
 
       # System Monitoring
-      "istat-menus" # iStat Menus - Professional menubar system monitoring (licensed app)
+      "stats" # Stats - Open-source menubar system monitor (replaced the licensed iStat Menus, 2026-08)
 
       # Messaging
       "telegram" # Telegram - Cross-platform messaging with cloud sync

--- a/docs/REQUIREMENTS.md
+++ b/docs/REQUIREMENTS.md
@@ -172,7 +172,7 @@ Consistency: 100% (declarative config)
    - Daily garbage collection (cleanup old Nix generations)
    - Daily Nix store optimization (deduplication)
    - Health check commands
-   - System monitoring (btop, iStat Menus, Beszel with macmon telemetry)
+   - System monitoring (Stats, mactop, Beszel with macmon telemetry)
 
 5. **Version Control & Rollback**
    - Entire system configuration in Git
@@ -259,7 +259,7 @@ Consistency: 100% (declarative config)
 
 2. **Homebrew Casks** (for GUI apps that don't work well in Nix)
    - Applications: Firefox, Zed, Claude Desktop, etc.
-   - System tools: 1Password, iStat Menus
+   - System tools: 1Password, Stats
    - Managed declaratively via nix-darwin's homebrew module
 
 3. **Mac App Store (mas)** (only when no alternative)
@@ -346,7 +346,7 @@ Consistency: 100% (declarative config)
 - Calibre (ebook manager)
 - Kindle (via mas)
 - Keka (archiver)
-- iStat Menus 🔒
+- Stats (open source)
 - Beszel monitoring with macmon as its headless telemetry backend
 - Acceptance: Apps installed, 🔒 apps documented as needing manual license activation
 
@@ -521,10 +521,10 @@ Consistency: 100% (declarative config)
 
 **REQ-MAINT-003**: System Monitoring Tools
 - btop (CLI system monitor)
-- iStat Menus (GUI menubar monitor) 🔒
+- Stats (GUI menubar monitor, open source)
 - Beszel agent (remote/time-series monitoring)
 - macmon (headless telemetry backend for the health API; not a user-facing monitor)
-- Acceptance: btop shows CPU/memory, iStat appears in the menubar, and health API metrics feed Beszel
+- Acceptance: mactop shows CPU/memory, Stats appears in the menubar, and health API metrics feed Beszel
 
 **REQ-MAINT-004**: Health Check Commands
 - `health-check` alias: validates system state
@@ -543,7 +543,7 @@ Consistency: 100% (declarative config)
 - Acceptance: Non-technical user can follow and complete install
 
 **REQ-DOC-002**: Licensed App Activation Guide
-- List of apps requiring manual activation: 1Password, iStat Menus, Little Snitch, NordVPN
+- List of apps requiring manual activation: 1Password, Little Snitch, NordVPN
 - Step-by-step for each app
 - Acceptance: User can activate all licenses within 15 minutes
 
@@ -896,7 +896,7 @@ Consistency: 100% (declarative config)
 
 - [ ] Daily garbage collection (launchd job)
 - [ ] Daily store optimization (launchd job)
-- [ ] Install btop and iStat Menus; configure Beszel with the macmon telemetry backend
+- [ ] Install Stats; configure Beszel with the macmon telemetry backend
 - [ ] Health check alias/script
 - [ ] Test: GC runs overnight, health-check reports status
 
@@ -950,7 +950,7 @@ Consistency: 100% (declarative config)
 - [ ] Fresh macOS reinstall on MacBook Pro M3 Max
 - [ ] Run bootstrap script (should be identical to VM experience)
 - [ ] Verify all workflows functional (work + dev)
-- [ ] Activate licensed apps (1Password, iStat Menus, NordVPN, Little Snitch, Office 365, etc.)
+- [ ] Activate licensed apps (1Password, NordVPN, Little Snitch, Office 365, etc.)
 - [ ] Use as daily driver for 1 week minimum
 - [ ] Document any hardware-specific issues (vs VM)
 
@@ -1202,7 +1202,7 @@ Consistency: 100% (declarative config)
 | Keka | Homebrew Cask | GUI app |
 | **Monitoring** | | |
 | btop | Home Manager (programs.btop) | Owns both package and user configuration |
-| iStat Menus | Homebrew Cask | GUI app |
+| Stats | Homebrew Cask | GUI app |
 | Beszel agent | Nix (nixpkgs.beszel) | Remote/time-series monitoring |
 | macmon | Nix (nixpkgs.macmon) | Headless health API telemetry backend |
 | **Communication** | | |
@@ -1395,7 +1395,7 @@ Consistency: 100% (declarative config)
 │  │  2. Activate licensed apps:                          │  │
 │  │     - 1Password (sign in)                            │  │
 │  │     - NordVPN (sign in)                              │  │
-│  │     - iStat Menus (enter license)                    │  │
+│  │     - Little Snitch (enter license)                  │  │
 │  │     - Office 365 (sign in with Microsoft account)    │  │
 │  │     - [Full list: ~/Documents/nix-install/docs/       │  │
 │  │        licensed-apps.md]                             │  │
@@ -1431,7 +1431,7 @@ Consistency: 100% (declarative config)
 | **Productivity** | ✅ Same (1Password, etc.) | ✅ Same |
 | **Communication** | ✅ Same (Telegram, WhatsApp) | ✅ Same |
 | **Media** | ✅ Same (VLC, GIMP) | ✅ Same |
-| **Monitoring** | ✅ Same (btop, iStat, Beszel/macmon backend) | ✅ Same |
+| **Monitoring** | ✅ Same (mactop, Stats, Beszel/macmon backend) | ✅ Same |
 | **System Config** | ✅ Same (Finder, trackpad, security) | ✅ Same |
 | **Shell Environment** | ✅ Same (Zsh, Oh My Zsh, Ghostty) | ✅ Same |
 | **Theming** | ✅ Same (Catppuccin) | ✅ Same |

--- a/docs/apps/README.md
+++ b/docs/apps/README.md
@@ -139,7 +139,7 @@ docs/apps/
 ├── security/
 │   └── nordvpn.md                      # NordVPN VPN service
 └── system/
-    └── system-monitoring.md            # btop, iStat Menus, Beszel/macmon telemetry
+    └── system-monitoring.md            # mactop, Stats, Beszel/macmon telemetry
 ```
 
 ---
@@ -159,7 +159,7 @@ docs/apps/
 - [REQUIREMENTS.md](../REQUIREMENTS.md) - Full project requirements and app inventory
 - [Development Progress](../development/README.md) - Story implementation status
 - [Homebrew Configuration](../../darwin/homebrew.nix) - App installation declarations
-- [Licensed Apps Guide](../licensed-apps.md) - Office 365 and licensed-app activation (1Password, iStat Menus, NordVPN, etc.)
+- [Licensed Apps Guide](../licensed-apps.md) - Office 365 and licensed-app activation (1Password, NordVPN, Little Snitch, etc.)
 
 ---
 

--- a/docs/apps/system/system-monitoring.md
+++ b/docs/apps/system/system-monitoring.md
@@ -1,5 +1,5 @@
 # ABOUTME: Documents the rationalised interactive and remote monitoring stack
-# ABOUTME: Covers btop, iStat Menus, Beszel, and the macmon telemetry backend
+# ABOUTME: Covers mactop, Stats, Beszel, and the macmon telemetry backend
 
 # System Monitoring
 
@@ -7,13 +7,13 @@ The repository deliberately keeps one tool for each monitoring role:
 
 | Role | Tool | Manager |
 |---|---|---|
-| Terminal diagnostics | btop | Home Manager |
-| Native menu-bar overview | iStat Menus | Homebrew cask |
+| Terminal diagnostics | mactop | Nix (system packages) |
+| Native menu-bar overview | Stats | Homebrew cask |
 | Remote history and alerts | Beszel agent | nixpkgs/nix-darwin |
 | Apple Silicon metrics backend | macmon | nixpkgs/nix-darwin |
 
 `gotop` and `mactop` are intentionally not installed. Their interactive
-features overlap with btop and iStat Menus. macmon remains installed only
+features overlap with mactop and Stats. macmon remains installed only
 because the health API uses its JSON output for cached Apple Silicon metrics.
 
 ## Data flow
@@ -26,40 +26,39 @@ macmon -> health-api /metrics -> vitals sampler / health checks
 The health API runs macmon on a bounded background interval and serves cached
 results. Requests never start their own macmon subprocess.
 
-## btop
+## mactop
 
-btop is the default terminal monitor for live CPU, memory, process, disk, and
-network diagnostics. Home Manager owns both the package and its Catppuccin
-configuration.
+mactop is the terminal monitor for live Apple Silicon diagnostics: per-cluster
+E/P CPU, GPU, ANE, power draw, and thermals. Nix owns the package (Power and
+Standard profiles). It replaced btop in v2.3.0 — btop's generic Linux-style
+view could not see Apple Silicon's cluster topology or power counters.
 
 ```sh
-btop
+sudo mactop
 ```
+
+`sudo` is required to read the SMC power and thermal counters.
 
 Key controls:
 
 - `q`: quit
-- `1`–`4`: switch panels
-- `f`: filter processes
-- `k`: terminate the selected process
-- `m`: change process sorting
+- `l`: change layout
+- `c`: change colour scheme
+- `/`: search the process list
+- `F9`: terminate the selected process
 
-Configuration is generated at `~/.config/btop/btop.conf`.
+## Stats
 
-## iStat Menus
-
-iStat Menus provides the always-visible native macOS overview. It requires a
-license or trial and is installed as the `istat-menus` Homebrew cask.
+Stats provides the always-visible native menu-bar overview. It is open source
+(github.com/exelban/stats) and installed as the `stats` Homebrew cask — it
+replaced the commercial iStat Menus in v2.11.0, removing a licence key from the
+post-install path.
 
 After installation:
 
-1. Launch iStat Menus and activate the license or trial.
-2. Import `config/istat-menus/iStat Menus Settings.ismp7` if desired.
-3. Disable automatic update checks so upgrades remain controlled by the repo.
-4. Grant requested macOS permissions for the sensors you enable.
-
-See [Licensed Applications](../../licensed-apps.md#istat-menus) for activation
-and troubleshooting details.
+1. Launch Stats and choose which modules appear in the menu bar.
+2. Grant the macOS permissions requested for the sensors you enable.
+3. The cask declares `auto_updates`, so Stats updates itself outside `rebuild`.
 
 ## Beszel
 
@@ -107,15 +106,15 @@ Relevant services and scripts:
 
 ## Verification checklist
 
-- [ ] `command -v btop` resolves through the Home Manager user profile.
-- [ ] `/Applications/iStat Menus.app` exists and the menu-bar items appear.
-- [ ] `gotop` and `mactop` are not found in `PATH`.
+- [ ] `command -v mactop` resolves through the system profile.
+- [ ] `/Applications/Stats.app` exists and the menu-bar items appear.
+- [ ] `gotop` and `btop` are not found in `PATH`.
 - [ ] `/metrics` returns cached CPU, memory, thermal, and process data.
 - [ ] The Beszel agent is loaded and connected when a hub key is configured.
 
 ## Troubleshooting
 
-If btop is missing, rebuild the active profile and start a new shell.
+If mactop is missing, rebuild the active profile and start a new shell.
 
 If `/metrics` reports that macmon is unavailable, confirm the system profile
 contains `/run/current-system/sw/bin/macmon` and inspect

--- a/docs/licensed-apps.md
+++ b/docs/licensed-apps.md
@@ -17,7 +17,6 @@ This document provides guidance for applications that require licenses, subscrip
 |-----|------|------|----------|
 | **1Password** | Sign-in | 2 min | High (password access) |
 | **NordVPN** | Sign-in | 2 min | Medium (VPN access) |
-| **iStat Menus** | License key | 1 min | Low (trial available) |
 | **Little Snitch** | License key | 2 min | Low (trial available) |
 | **Office 365** | Sign-in | 3 min | If needed |
 
@@ -37,7 +36,6 @@ The following apps require manual setup after installation:
 - **NordVPN**: Requires active subscription (NO free tier, $3.99-$12.99/month)
 
 **System Monitoring**:
-- **iStat Menus**: Commercial software ($11.99 USD) with 14-day free trial
 
 **Development Tools**:
 - None currently (all dev tools are free/open source)
@@ -135,152 +133,6 @@ The following apps require manual setup after installation:
 
 ---
 
-### iStat Menus
-
-**Installation**: Installed via Homebrew cask `istat-menus` (Story 02.4-006)
-
-**License Requirement**: iStat Menus is **commercial software** requiring a paid license. Offers a 14-day free trial with full features.
-
-**License Options**:
-
-1. **Free Trial** (14 days):
-   - Full features unlocked for 14 days
-   - No credit card required
-   - No account sign-up needed
-   - Trial countdown visible in Preferences → License
-   - After expiration: App becomes read-only (settings locked, displays still visible)
-
-2. **Paid License** (One-time purchase):
-   - **Price**: $11.99 USD (one-time, no subscription)
-   - **Lifetime license**: No recurring fees
-   - **Free updates**: Lifetime updates for current major version
-   - **Multi-Mac**: Use on all your Macs (personal use)
-   - **Purchase**: https://bjango.com/mac/istatmenus/
-
-**Activation Steps**:
-
-**Option A: Start Free Trial**
-1. Launch iStat Menus from Spotlight (`Cmd+Space`, type "iStat Menus") or `/Applications/iStat Menus.app`
-2. Welcome screen appears on first launch
-3. Click **Start Free Trial** button
-4. Trial activates immediately (no sign-up or credit card required)
-5. All features unlocked for 14 days
-6. Menubar icons appear for enabled sensors (CPU, Memory, Network, etc.)
-7. Check trial status: Click any menubar icon → Preferences → License → "XX days remaining"
-
-**Option B: Enter Existing License**
-1. Launch iStat Menus
-2. Welcome screen appears → Click **Enter License** button
-3. Enter **License Name** (your name or email used during purchase, case-sensitive)
-4. Enter **License Key** (from purchase confirmation email)
-5. Click **Activate** button
-6. License validates → App is permanently activated
-7. Verify: Preferences → License → "Licensed to: [Your Name]"
-
-**Option C: Purchase License**
-
-**During Trial**:
-1. Click any iStat Menus menubar icon (CPU, Memory, etc.)
-2. Click **Preferences** at bottom of dropdown
-3. Click **License** tab
-4. Click **Buy Now** button
-5. Browser opens to https://bjango.com/mac/istatmenus/
-6. Complete purchase ($11.99 USD via credit card or PayPal)
-7. License key sent to email within minutes
-8. Return to iStat Menus → Enter license (see Option B above)
-
-**From Website**:
-1. Visit https://bjango.com/mac/istatmenus/ in browser
-2. Click **Buy** button (top right or in pricing section)
-3. Complete purchase ($11.99 USD)
-4. License key sent to purchase email
-5. Launch iStat Menus → Click **Enter License** → Enter details (see Option B)
-
-**License Verification**:
-```bash
-# Check license status
-# Click any iStat Menus menubar icon → Preferences → License tab
-# Should show one of:
-# - "Trial: XX days remaining" (trial period active)
-# - "Licensed to: [Your Name]" (license activated)
-# - "Trial expired - Purchase required" (trial ended, need license)
-```
-
-**Auto-Update Disable** (CRITICAL):
-iStat Menus has automatic updates **enabled by default**. You **MUST** disable auto-update:
-
-1. Click any iStat Menus menubar icon → **Preferences**
-2. Click **General** tab (top of Preferences window)
-3. Scroll down to **Updates** section
-4. **Uncheck** "Automatically check for updates"
-5. Close Preferences → Setting is saved
-6. Verify: Reopen Preferences → General → Updates → Checkbox should remain unchecked
-
-**Why disable auto-update**:
-- All app updates controlled by `darwin-rebuild switch` (Homebrew version pinning)
-- Ensures reproducible system state (no surprise updates)
-- Prevents automatic app restarts during updates
-
-**What Happens After Trial Expires**:
-- iStat Menus becomes **read-only**:
-  - Menubar displays **still visible** (can view stats)
-  - **Cannot change settings** (Preferences menu locked)
-  - **Cannot customize** sensors or display format
-- To regain full functionality:
-  - Purchase license ($11.99 USD)
-  - Enter license key (see Option B above)
-  - All settings immediately unlocked
-
-**License Benefits**:
-- **Lifetime license**: Pay once, use forever (no subscription)
-- **Free updates**: All updates for current major version (iStat Menus 7.x)
-- **Multiple Macs**: Install on all your personal Macs (license allows personal use across devices)
-- **Offline activation**: License verified offline after initial activation (no internet required)
-- **Support**: Email support at support@bjango.com
-
-**Common Issues**:
-
-**License Key Not Accepted**:
-- **Cause**: Typo in license name or key, extra spaces
-- **Solution**:
-  - Verify license name matches purchase email **exactly** (case-sensitive)
-  - Copy license key from email (avoid manual typing)
-  - Check for spaces at start/end of license name/key
-  - Try entering on different Mac (license is multi-Mac compatible)
-
-**License Key Lost**:
-- **Solution**: Contact Bjango support
-  - Email: support@bjango.com
-  - Subject: "License key recovery"
-  - Include: Purchase email address, transaction ID (if available)
-  - Response time: Usually within 24 hours
-  - Bjango will resend license key to purchase email
-
-**Trial Expired, Can't Afford License**:
-- **No free alternative in iStat Menus** (commercial software)
-- **Free alternatives** (if license not feasible):
-  - **btop**: Free terminal system monitor (installed via Home Manager)
-  - **Activity Monitor**: Built-in macOS app (Utilities → Activity Monitor)
-  - **Note**: Free alternatives lack menubar integration and some advanced features
-
-**Auto-Update Still Enabled After Disabling**:
-- **Solution**:
-  - Verify: Preferences → General → Updates → "Automatically check for updates" is **unchecked**
-  - If checked: Uncheck again → Close Preferences → Reopen to confirm persistence
-  - Also check: System Settings → App Store → Uncheck "Automatic Updates" (system-wide)
-  - If installed via Homebrew (our setup): Updates only via `darwin-rebuild switch`
-
-**Menubar Icons Not Appearing**:
-- **Cause**: Sensors disabled in Preferences
-- **Solution**:
-  - Preferences → Menubar Items
-  - Enable desired sensors: CPU, Memory, Network, Disk, Battery, Sensors
-  - Check "Show in menubar" for each enabled sensor
-  - Icons appear immediately after enabling
-
-**Documentation**: For full iStat Menus usage and configuration, see `docs/apps/system/system-monitoring.md` → iStat Menus section.
-
----
 
 ## Office & Productivity Suites
 
@@ -528,7 +380,6 @@ with full knowledge that updates are no longer managed by `rebuild`.
 | App | Installation | Account Type | Cost | Activation Required |
 |-----|-------------|--------------|------|---------------------|
 | **1Password** | Homebrew cask | Subscription or License | $2.99+/month or legacy | Yes (required) |
-| **iStat Menus** | Homebrew cask | One-time purchase | $11.99 USD (14-day trial) | Yes (trial or license) |
 | **NordVPN** | Homebrew cask | Subscription | $3.99-$12.99/month | Yes (required) |
 | **Office 365** | Manual install | Subscription | $69.99+/year or company | Yes (required) |
 

--- a/docs/post-install.md
+++ b/docs/post-install.md
@@ -50,7 +50,6 @@ Activate apps requiring sign-in or license keys. See [Licensed Apps Guide](./lic
 - [ ] **NordVPN** - Sign in, grant network extension permission
 
 **License Key Apps** (~2 minutes):
-- [ ] **iStat Menus** - Enter license key (or start 14-day trial)
 - [ ] **Little Snitch** - Enter license key (or start trial)
 
 **Disable Auto-Updates** (CRITICAL):

--- a/tests/monitoring_stack.bats
+++ b/tests/monitoring_stack.bats
@@ -36,17 +36,21 @@ setup() {
     run rg -n '^[[:space:]]+mactop[[:space:]]*(#.*)?$' "$DARWIN_CONFIG"
     [ "$status" -eq 0 ]
 
-    run rg -n '"istat-menus"' "$HOMEBREW_CONFIG"
+    # Stats (open source) replaced the licensed iStat Menus on 2026-08-06
+    run rg -n '"stats"' "$HOMEBREW_CONFIG"
     [ "$status" -eq 0 ]
+
+    run rg -n '"istat-menus"' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 1 ]
 
     run rg -n '\$\{pkgs\.beszel\}/bin/beszel-agent' "$MONITORING_MODULE"
     [ "$status" -eq 0 ]
 }
 
 @test "README advertises only the rationalised stack" {
-    run rg -n 'System & Monitoring.*iStat Menus.*mactop.*Beszel' "$README_FILE"
+    run rg -n 'System & Monitoring.*Stats.*mactop.*Beszel' "$README_FILE"
     [ "$status" -eq 0 ]
 
-    run rg -n 'System & Monitoring.*(gotop|btop)' "$README_FILE"
+    run rg -n 'System & Monitoring.*(gotop|btop|iStat)' "$README_FILE"
     [ "$status" -eq 1 ]
 }


### PR DESCRIPTION
Swaps the licensed `istat-menus` cask for [`stats`](https://github.com/exelban/stats).

## Why it matters beyond the swap
iStat Menus was a **licensed** app, so retiring it removes a licence key from the entire post-install path — `licensed-apps.md` (table row, cost note, dedicated section), `post-install.md`'s activation checklist, and three activation lists in `REQUIREMENTS.md` all lose an entry. One less thing to re-enter on a fresh machine.

## Tests
The two monitoring tests asserted iStat Menus **was** present. Inverted rather than deleted: `stats` must be present, `istat-menus` absent. Verified red → green.

## Drift repaired along the way
`docs/apps/system/system-monitoring.md` still documented **btop** as the terminal monitor — retired in v2.3.0, so three months of instructions pointing at a tool that isn't installed. Rewritten for mactop (including the `sudo` requirement for SMC power/thermal counters), and its verification checklist corrected: it asserted *"gotop and mactop are not found in PATH"*, the exact opposite of current reality.

## Left deliberately
`config/istat-menus/iStat Menus Settings.ismp7` stays tracked — a tuned layout export that cannot be regenerated now the app is uninstalled (same reasoning as leaving Raycast's user settings alone).

## Note
The `stats` cask declares `auto_updates`, so it self-updates outside `rebuild` — same as cmux. Documented in the guide.

## Machine
Stats installed (already latest), iStat Menus 7.30 uninstalled with a Caskroom backup.

Gates: `make test` 314/314 zero failures; `make nix-eval` clean on all 3 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)