### PR TITLE
feat(homebrew): add openusage cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 **AI & LLM Tools**:
 - Claude Desktop, Claude Code CLI (from `claude-code-nix` flake)
 - ChatGPT, Codex CLI (OpenAI's terminal coding agent)
+- OpenUsage (usage/spend tracker for Claude Code, Codex, Copilot et al.)
 - OpenCode and Qwen Code (open source AI coding agents for the terminal). On Power, OpenCode defaults to the **local** `qwen3.6-coding:opencode` model over Ollama — no cloud round-trip
 - Ollama (Power: `gemma4:e4b` + `gemma4:26b` + `qwen3.6:35b-a3b-coding-nvfp4` + `nomic-embed-text`; Standard: `ministral-3:14b` + `nomic-embed-text`; AI-Assistant: `nomic-embed-text`)
 - MLX-LM 0.21.0 (Apple Silicon, isolated uv environment at `~/.local/share/mlx-lm/venv`)
@@ -486,7 +487,7 @@ nix-install/
 | **Tests** | 1,461 test cases (47 BATS files, 313 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
-| **Packages** | 30 casks (15 on AI-Assistant, 30 on Power), 11 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |
+| **Packages** | 31 casks (16 on AI-Assistant, 31 on Power), 11 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |
 
 **Next**: MacBook Air M4 migration (Phase 11) · Story 08.3-008 (one-day mactop-free validation) · Story 09.1-008 (Privacy Filter verification on hardware)
 

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -72,6 +72,10 @@ in
       # AI & LLM Tools (Story 02.1-001, 02.1-002)
       "claude" # Claude Desktop - Anthropic's AI assistant
       "chatgpt" # ChatGPT Desktop - OpenAI's conversational AI
+      # Usage/spend tracker for Claude Code, Codex, Copilot et al. All profiles,
+      # since Claude Code runs on every one. Declares auto_updates, so it
+      # self-updates outside `rebuild` (same exception as cmux and stats).
+      "openusage" # OpenUsage - AI coding-agent usage tracker
       # OpenAI Codex CLI - terminal coding agent.
       #
       # The cask vendors ad-hoc-signed helper binaries (codex-path/rg,


### PR DESCRIPTION
Declares [OpenUsage](https://www.openusage.ai/) — a usage/spend tracker for Claude Code, Codex, Copilot and other AI coding agents. Already installed on this machine (0.7.6); this makes it reproducible.

## Decisions
- **All profiles, not Power-only.** No profile was specified; Claude Code runs on every profile, and at 53MB it does not meaningfully weigh down the deliberately-minimal AI-Assistant machine. Easy to gate later if that is wrong.
- **No test.** Plain casks with no profile gating and no retirement to guard follow the `obsidian`/`plaud` precedent of being untested — a test here would be ceremony rather than a guard.

## Note
The cask declares `auto_updates`, so OpenUsage self-updates outside `rebuild` — the **third** such exception after cmux and stats. Worth watching as a slow drift from the repo's no-auto-updates principle.

Gates: `make test` 314/314 zero failures; `make nix-eval` clean on all 3 profiles. README documents it in the AI tools list; package count → 31 casks (16 on AI-Assistant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)