### PR TITLE
feat(defaults): pin self-updating casks and guard the no-auto-update policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,461 test cases (47 BATS files, 313 in the active gate) |
+| **Tests** | 1,463 test cases (48 BATS files, 315 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 31 casks (16 on AI-Assistant, 31 on Power), 11 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |

--- a/darwin/macos-defaults.nix
+++ b/darwin/macos-defaults.nix
@@ -316,6 +316,30 @@
   # Story 03.4-001: Auto Light/Dark Mode and Icon/Widget Style
   # CustomUserPreferences allows setting options not directly supported by nix-darwin
   system.defaults.CustomUserPreferences = {
+    # ==========================================================================
+    # SELF-UPDATING CASK LOCKDOWN
+    # ==========================================================================
+    # cmux, Stats and OpenUsage all ship `auto_updates`, which lets them update
+    # themselves and bypass `rebuild` — the one mechanism this repo says owns
+    # app versions. Disabling it in each app's settings panel works but is
+    # machine-local: it does not survive a fresh install, an app reinstall, or
+    # propagate to the other MacBooks. Declaring it here does.
+    #
+    # cmux and OpenUsage use the Sparkle framework; Stats has its own key.
+    "com.cmuxterm.app" = {
+      SUEnableAutomaticChecks = false;
+      SUAutomaticallyUpdate = false;
+    };
+
+    "com.robinebers.openusage" = {
+      SUEnableAutomaticChecks = false;
+      SUAutomaticallyUpdate = false;
+    };
+
+    "eu.exelban.Stats" = {
+      "update-interval" = "Never";
+    };
+
     # Enable automatic appearance switching (Light/Dark mode)
     # macOS will switch based on sunrise/sunset times
     NSGlobalDomain = {

--- a/tests/auto_update_policy.bats
+++ b/tests/auto_update_policy.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+# ABOUTME: Guards the repo's "no auto-updates, rebuild is the only mechanism" principle
+# ABOUTME: Casks that ship auto_updates must have their updater pinned off declaratively
+
+setup() {
+    REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+    HOMEBREW_CONFIG="${REPO_ROOT}/darwin/homebrew.nix"
+    MACOS_DEFAULTS="${REPO_ROOT}/darwin/macos-defaults.nix"
+}
+
+@test "Homebrew neither auto-updates nor upgrades on its own" {
+    run rg -n 'autoUpdate = false' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'upgrade = false' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'HOMEBREW_NO_AUTO_UPDATE = "1"' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+}
+
+@test "self-updating casks have their updaters pinned off declaratively" {
+    # cmux, stats and openusage all ship `auto_updates`, which would otherwise
+    # bypass rebuild entirely. Toggling this in each app's settings panel is
+    # machine-local and does not survive a fresh install, so it is declared.
+    run rg -n '"com\.cmuxterm\.app"' "$MACOS_DEFAULTS"
+    [ "$status" -eq 0 ]
+
+    run rg -n '"com\.robinebers\.openusage"' "$MACOS_DEFAULTS"
+    [ "$status" -eq 0 ]
+
+    run rg -n '"eu\.exelban\.Stats"' "$MACOS_DEFAULTS"
+    [ "$status" -eq 0 ]
+
+    # Sparkle's automatic check must be off wherever it is declared
+    run rg -n 'SUEnableAutomaticChecks = true' "$MACOS_DEFAULTS"
+    [ "$status" -eq 1 ]
+}

--- a/tests/run-safe-suite.sh
+++ b/tests/run-safe-suite.sh
@@ -16,6 +16,7 @@ for command_name in "${required_commands[@]}"; do
 done
 
 safe_bats_suites=(
+    tests/auto_update_policy.bats
     tests/bootstrap_flake_clone.bats
     tests/bootstrap_preflight.bats
     tests/calibre_local_library.bats


### PR DESCRIPTION
Three casks — **cmux**, **Stats**, **OpenUsage** — ship `auto_updates`, letting them update themselves and bypass `rebuild`, the one mechanism this repo says owns app versions.

FX disabled them in each app's settings panel, which works but is **machine-local**: it survives neither a fresh install nor an app reinstall, and never reaches the other three MacBooks. Declaring it in `CustomUserPreferences` (the same block that manages Light/Dark switching) makes it a guarantee.

| App | Domain | Keys |
|---|---|---|
| cmux | `com.cmuxterm.app` | `SUEnableAutomaticChecks`, `SUAutomaticallyUpdate` |
| OpenUsage | `com.robinebers.openusage` | `SUEnableAutomaticChecks`, `SUAutomaticallyUpdate` |
| Stats | `eu.exelban.Stats` | `update-interval = "Never"` |

Both Sparkle keys are set: disabling checks stops it *looking*, `SUAutomaticallyUpdate` stops it *installing* if a check happens anyway.

## Found while checking
cmux's `SUEnableAutomaticChecks` still read **`1`** despite the settings-panel toggle — so one of the three was not actually disabled. The next `rebuild` corrects it.

## The policy had no test at all
Nothing in the suite guarded `autoUpdate = false`, `upgrade = false`, or `HOMEBREW_NO_AUTO_UPDATE` — the repo's stated first principle was entirely unverified. `tests/auto_update_policy.bats` now covers it end to end, including a negative assertion that `SUEnableAutomaticChecks = true` never appears. Any future `auto_updates` cask has an obvious home for its lockdown.

Gates: `make test` 315/315 zero failures; `make nix-eval` clean on all 3 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)