### PR TITLE
fix(fluidvoice): give the activation build access to /usr/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,463 test cases (48 BATS files, 315 in the active gate) |
+| **Tests** | 1,464 test cases (48 BATS files, 316 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 31 casks (16 on AI-Assistant, 31 on Power), 11 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |

--- a/home-manager/modules/fluidvoice.nix
+++ b/home-manager/modules/fluidvoice.nix
@@ -56,10 +56,17 @@ in
       echo "• FluidVoice: full Xcode not available — skipping (Power profile installs it)"
     else
       echo "Building FluidVoice from $APP_SRC..."
+      # Home Manager's activation PATH is Nix-only, but this build shells out
+      # to system tools: install-app.sh runs `awk` to pick a signing identity,
+      # and SwiftPM needs `unzip` to unpack the CTranscribe xcframework. Both
+      # live in /usr/bin, and without them the build dies part-way through
+      # dependency resolution (observed 2026-08-06). Appended rather than
+      # prepended so Nix-provided tools still win where they exist.
+      #
       # Invoked inside `if` so a non-zero exit is absorbed: activation runs
       # under `set -e`, and a failed optional app build must never take down
       # the whole rebuild.
-      if $DRY_RUN_CMD bash "$APP_SRC/scripts/install-app.sh" "${config.home.homeDirectory}/Applications"; then
+      if PATH="$PATH:/usr/bin:/bin" $DRY_RUN_CMD bash "$APP_SRC/scripts/install-app.sh" "${config.home.homeDirectory}/Applications"; then
         echo "✓ FluidVoice installed to ~/Applications"
       else
         echo "⚠ FluidVoice build failed — the app was left as-is" >&2

--- a/tests/communication_tooling.bats
+++ b/tests/communication_tooling.bats
@@ -26,6 +26,17 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "FluidVoice build can reach the system tools it shells out to" {
+    module="${BATS_TEST_DIRNAME}/../home-manager/modules/fluidvoice.nix"
+
+    # Home Manager's activation PATH is Nix-only. install-app.sh calls awk to
+    # pick a signing identity, and SwiftPM needs unzip to unpack the
+    # CTranscribe xcframework - both live in /usr/bin. Without it the build
+    # dies during dependency resolution (observed 2026-08-06).
+    run rg -n 'PATH=.*(/usr/bin)' "$module"
+    [ "$status" -eq 0 ]
+}
+
 @test "Qobuz is installed only for the Power profile" {
     run rg -U -n '\+\+ lib\.optionals \(profileName == "power"\) \[[^;]+"qobuz"' \
         "$HOMEBREW_CONFIG"


### PR DESCRIPTION
The 2026-08-06 rebuild failed to build FluidVoice:

```
install-app.sh: line 36: awk: command not found
... could not find executable for 'unzip'
```

**Root cause:** Home Manager's activation PATH is Nix-only, but this build shells out to system tools — `awk` (picking a signing identity) and `unzip` (SwiftPM unpacking the CTranscribe xcframework). Both live in `/usr/bin`. Reproduced exactly: under the activation PATH both are missing; with `/usr/bin` appended both resolve.

Appended rather than prepended so Nix-provided tools still win where they exist. The module already used an absolute `/usr/bin/xcodebuild` for its capability check — so the author had hit this before, just not for the build itself.

## Why it matters more than it looks
The failure was **contained** — the module's `⚠ build failed — the app was left as-is` guard kept the working app in place (verified still FX's fork, signed `Apple Development: itunes@fxmartin.me`, built Aug 5). But the Homebrew cask was retired in v2.10.0, so this build is now the **only** install path. A silent failure here eventually means no FluidVoice at all.

Test asserts the module keeps `/usr/bin` on the build PATH, with the failure date recorded so the reason survives.

Gates: `make test` 316/316 zero failures; `make nix-eval` clean on all 3 profiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)