### PR TITLE
feat(homebrew): add llama.cpp formula for direct GGUF work

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 - OpenUsage (usage/spend tracker for Claude Code, Codex, Copilot et al.)
 - OpenCode and Qwen Code (open source AI coding agents for the terminal). On Power, OpenCode defaults to the **local** `qwen3.6-coding:opencode` model over Ollama — no cloud round-trip
 - Ollama (Power: `gemma4:e4b` + `gemma4:26b` + `qwen3.6:35b-a3b-coding-nvfp4` + `nomic-embed-text`; Standard: `ministral-3:14b` + `nomic-embed-text`; AI-Assistant: `nomic-embed-text`)
+- llama.cpp (`llama-server`, `llama-cli` — GGUF inference with Metal)
 - MLX-LM 0.21.0 (Apple Silicon, isolated uv environment at `~/.local/share/mlx-lm/venv`)
 - **Privacy Filter** — on-device PII redaction (MLX port of OpenAI's open-weight Privacy Filter via OpenMed). Always-on LaunchAgent on `127.0.0.1:7790`; BF16 variant on Power, 8-bit on Standard / AI-Assistant. Workflow: `pbcopy` → `redact-clip` → paste into Claude/ChatGPT (Epic-09).
 
@@ -484,10 +485,10 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,464 test cases (48 BATS files, 316 in the active gate) |
+| **Tests** | 1,465 test cases (48 BATS files, 317 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
-| **Packages** | 31 casks (16 on AI-Assistant, 31 on Power), 11 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |
+| **Packages** | 31 casks (16 on AI-Assistant, 31 on Power), 12 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |
 
 **Next**: MacBook Air M4 migration (Phase 11) · Story 08.3-008 (one-day mactop-free validation) · Story 09.1-008 (Privacy Filter verification on hardware)
 

--- a/darwin/homebrew.nix
+++ b/darwin/homebrew.nix
@@ -46,6 +46,12 @@ in
       "pkgconf" # pkg-config implementation required by native Python extension builds
 
       # AI & LLM Tools
+      # llama.cpp via Homebrew rather than nixpkgs `llama-cpp`: the formula
+      # tracks upstream far more closely (10250 vs nixpkgs 10133 when added),
+      # which matters for a project releasing several times a day, and the
+      # bottle ships with Metal enabled. Declaring both would put two
+      # `llama-server` binaries on PATH — see the package-boundary test.
+      "llama.cpp" # llama.cpp - GGUF inference engine (llama-server, llama-cli)
       "ollama" # Ollama CLI - Local LLM server (replaces ollama-app cask)
       "opencode" # OpenCode - Open source AI coding agent for the terminal
       "qwen-code" # Qwen Code - Open source AI coding agent for the terminal

--- a/docs/apps/ai/ai-llm-tools.md
+++ b/docs/apps/ai/ai-llm-tools.md
@@ -1,5 +1,5 @@
 # ABOUTME: AI and LLM desktop applications configuration guide
-# ABOUTME: Covers Claude Desktop, ChatGPT Desktop, Ollama (CLI), OpenCode's local model, and Open WebUI
+# ABOUTME: Covers Claude Desktop, ChatGPT Desktop, Ollama, llama.cpp, OpenCode's local model, MLX-LM, and the Privacy Filter
 
 # AI & LLM Tools
 
@@ -148,6 +148,34 @@ automatic, and `--host 0.0.0.0` must **never** be copied — Ollama has no authe
 
 ---
 
+## llama.cpp (GGUF Inference Engine)
+
+**Status**: Installed via Homebrew formula `llama.cpp` — provides `llama-server`, `llama-cli`, and the GGUF tooling.
+
+**Why Homebrew, not nixpkgs**: nixpkgs ships `llama-cpp`, but the formula tracks
+upstream far more closely (10250 vs 10133 when this was added) — llama.cpp
+releases several times a day, and the bottle is built with Metal enabled.
+Declaring both would place two `llama-server` binaries on `PATH`; the
+package-boundary test in `tests/package_manager_boundaries.bats` guards against
+that.
+
+**Relationship to Ollama**: they overlap but are not redundant. Ollama manages a
+model library and a persistent daemon (and OpenCode's local model runs through
+it — see above). llama.cpp is the lower-level engine: direct GGUF files, full
+control over sampling and context flags, and a server whose parameters are set
+per launch rather than baked into a Modelfile.
+
+**Basic use**:
+```bash
+llama-cli -m model.gguf -p "prompt"          # one-shot
+llama-server -m model.gguf --host 127.0.0.1  # OpenAI-compatible API
+```
+
+**Keep the server on loopback.** `llama-server` has no authentication, exactly
+like Ollama — `--host 0.0.0.0` exposes an unauthenticated inference endpoint to
+the network.
+
+---
 ## MLX-LM (Apple-Native Runtime)
 
 **Status**: MLX-LM 0.21.0 is provisioned on Apple Silicon by Home Manager in an isolated uv environment at `~/.local/share/mlx-lm/venv`.

--- a/tests/mlx_lm_inferencer.bats
+++ b/tests/mlx_lm_inferencer.bats
@@ -41,7 +41,12 @@ setup() {
     run rg -n '"ollama"' "$HOMEBREW_MODULE"
     [ "$status" -eq 0 ]
 
-    run rg -n -i 'llama\.cpp|omlx|lm-studio|inferencer|dflash|turboquant|vllm-mlx|mtplx|mlc-llm|mlc-ai' \
+    # llama.cpp was removed from this forbidden list on 2026-08-07: it is now
+    # deliberately declared as a Homebrew formula for direct GGUF work
+    # (llama-server / llama-cli). Note Ollama already embeds llama.cpp as an
+    # internal runner — the formula adds standalone binaries, not a second
+    # inference stack for Ollama to use. The other runtimes below stay retired.
+    run rg -n -i 'omlx|lm-studio|inferencer|dflash|turboquant|vllm-mlx|mtplx|mlc-llm|mlc-ai' \
         "$HOME_MANAGER_CONFIG" "$MLX_LM_MODULE" "$HOMEBREW_MODULE"
     [ "$status" -eq 1 ]
 }

--- a/tests/package_manager_boundaries.bats
+++ b/tests/package_manager_boundaries.bats
@@ -27,6 +27,17 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "llama.cpp is owned only by Homebrew" {
+    # nixpkgs also ships llama-cpp; declaring both would put two `llama-server`
+    # binaries on PATH. Homebrew wins here because it tracks the project far
+    # more closely (10250 vs 10133 at time of writing) and llama.cpp moves fast.
+    run rg -n '"llama\.cpp"' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 0 ]
+
+    run rg -n '^[[:space:]]+llama-cpp([[:space:]]|#)' "$DARWIN_CONFIG"
+    [ "$status" -eq 1 ]
+}
+
 @test "GitHub CLI is owned only by Homebrew" {
     run rg -n '"gh"[[:space:]]+# GitHub CLI' "$HOMEBREW_CONFIG"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Adds `llama-server` / `llama-cli` for driving GGUF files directly, with per-launch control over sampling and context flags.

## ⚠️ This reverses a deliberate decision
llama.cpp sat on the **retired inferencer list** guarded by `tests/mlx_lm_inferencer.bats` since v1.9.0 — that test exists to *"prevent retired local inferencers from returning to declarative configuration"*.

The guard is **narrowed, not removed**: llama.cpp comes off the forbidden pattern with a dated comment explaining why; lm-studio, vllm-mlx, mlc-llm, omlx, dflash, turboquant and mtplx all stay blocked.

## Worth recording
**Ollama already embeds llama.cpp as an internal runner** (see `local-ai-menubar.md` — the app shows whether MLX or llama.cpp is serving). This formula therefore adds *standalone binaries*, not a better engine for Ollama. Useful for direct GGUF work; redundant if everything goes through Ollama.

## Homebrew over nixpkgs
| Source | Version |
|---|---|
| Homebrew formula | **10250** (bottled, Metal) |
| nixpkgs `llama-cpp` | 10133 |

117 builds apart on a project that releases several times a day. A new package-boundary test asserts llama.cpp is Homebrew-owned and absent from Nix system packages, so two `llama-server` binaries cannot both land on PATH.

## Docs
New section in `ai-llm-tools.md` covering the Ollama relationship, basic use, and a loopback warning — `llama-server` has no authentication, exactly like Ollama.

Gates: `make test` 317/317 zero failures; `make nix-eval` clean on all 3 profiles. README → 12 brews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)