### PR TITLE
feat: oMLX from notarized DMG + shared local model root

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ After installation, manage your system with these aliases:
 | `gc` | User-profile garbage collection |
 | `gc-system` | System-profile garbage collection (runs weekly as root LaunchDaemon) |
 | `cleanup` | Full cleanup (GC + store optimization) |
-| `disk-cleanup` | Prune development caches and report Codex storage opportunities |
+| `disk-cleanup` | Prune development caches; reports local model store (`--prune-models` to sweep it) |
 | `codex-cleanup` | Analyze Codex storage; compact logs or prune caches only with explicit flags |
 | `health-check` | System health report |
 | `curl localhost:7780/metrics` | Apple Silicon metrics (CPU per-cluster, GPU, ANE, memory, power, thermal, top-5 processes) |
@@ -187,6 +187,7 @@ Ground truth lives in [`darwin/homebrew.nix`](./darwin/homebrew.nix). Sections b
 - OpenCode and Qwen Code (open source AI coding agents for the terminal). On Power, OpenCode defaults to the **local** `qwen3.6-coding:opencode` model over Ollama — no cloud round-trip
 - Ollama (Power: `gemma4:e4b` + `gemma4:26b` + `qwen3.6:35b-a3b-coding-nvfp4` + `nomic-embed-text`; Standard: `ministral-3:14b` + `nomic-embed-text`; AI-Assistant: `nomic-embed-text`)
 - llama.cpp (`llama-server`, `llama-cli` — GGUF inference with Metal)
+- oMLX **[Power]** — menubar MLX inference server, installed from its notarized DMG (`darwin/omlx.nix`)
 - MLX-LM 0.21.0 (Apple Silicon, isolated uv environment at `~/.local/share/mlx-lm/venv`)
 - **Privacy Filter** — on-device PII redaction (MLX port of OpenAI's open-weight Privacy Filter via OpenMed). Always-on LaunchAgent on `127.0.0.1:7790`; BF16 variant on Power, 8-bit on Standard / AI-Assistant. Workflow: `pbcopy` → `redact-clip` → paste into Claude/ChatGPT (Epic-09).
 
@@ -485,7 +486,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,465 test cases (48 BATS files, 317 in the active gate) |
+| **Tests** | 1,468 test cases (48 BATS files, 320 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 31 casks (16 on AI-Assistant, 31 on Power), 12 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |

--- a/darwin/configuration.nix
+++ b/darwin/configuration.nix
@@ -12,6 +12,11 @@
   profileName,
   ...
 }:
+let
+  # Single root for every local model store a runtime can be pointed at, so
+  # disk-cleanup and the weekly digest have one path to sweep and report.
+  localModelRoot = "/Users/${userConfig.username}/models";
+in
 {
   # Nix package manager settings
   nix.enable = true;
@@ -227,8 +232,21 @@
   # JAVA_HOME for the Power profile's JDK. A JDK on PATH alone half-works:
   # `java` runs, but build tools and IDEs that resolve the toolchain by env var
   # do not. pkgs.jdk.home points at the macOS bundle's Contents/Home.
+  #
+  # LLAMA_CACHE / OMLX_MODEL_DIR put both local model stores under one root.
+  # They hold *different artefacts* — llama.cpp downloads GGUF files, oMLX wants
+  # MLX safetensors directories — so this saves no disk. The point is that one
+  # retention rule and one digest line can then cover all local model storage;
+  # left at their defaults (~/.cache/llama.cpp and ~/.omlx/models) they grow
+  # unbounded and invisibly, and GGUF/MLX weights run to tens of GB.
+  #
+  # Ollama deliberately does not join them: its models are content-addressed
+  # tensor blobs plus JSON manifests under ~/.ollama/models, not a plain
+  # directory any other runtime can read. `ollama-lru` prunes that store.
   environment.variables = lib.mkIf isPowerProfile {
     JAVA_HOME = "${pkgs.jdk.home}";
+    LLAMA_CACHE = "${localModelRoot}/gguf";
+    OMLX_MODEL_DIR = "${localModelRoot}/mlx";
   };
 
   # Application Management & System Configuration

--- a/darwin/omlx.nix
+++ b/darwin/omlx.nix
@@ -1,0 +1,86 @@
+# ABOUTME: Installs the oMLX menubar inference server from its notarized DMG (Power profile only)
+# ABOUTME: Pinned URL + SHA-256, with a Gatekeeper check before the app is copied into /Applications
+#
+# Why a DMG rather than Homebrew: oMLX has no cask, and its formula lives in an
+# untrusted third-party tap (`jundot/omlx`). Homebrew refuses to load untrusted
+# formulae, and the trust state lives in ~/.homebrew/trust.json — machine-local
+# and undeclarable — so a fresh install would fail at `brew bundle`. The DMG
+# carries an Apple-notarized Developer ID (Heejun Kim, PSK5Q5T46L), which is a
+# stronger identity guarantee than a Ruby formula and is verifiable here.
+#
+# The formula also built a 1.6GB Python venv by resolving dozens of unpinned
+# PyPI dependencies at install time. The DMG is a self-contained signed bundle.
+#
+# ⚠️ oMLX ships in-app auto-update. That means the installed version can drift
+# away from the pin below without a rebuild — the same exception cmux, Stats and
+# OpenUsage carry (see darwin/macos-defaults.nix). Disable it in the app's
+# settings; if a preference key surfaces, pin it there alongside the others.
+{
+  pkgs,
+  lib,
+  profileName,
+  ...
+}:
+let
+  omlxVersion = "0.5.7";
+
+  # macOS 26/27 build. The Sequoia (macos15) variant is a separate asset —
+  # switch the filename if this ever runs on an older machine.
+  omlxUrl = "https://github.com/jundot/omlx/releases/download/v${omlxVersion}/oMLX-${omlxVersion}-macos26-27.dmg";
+  omlxSha256 = "30934506f0834943f97f040110ea26409b5c98812dcb7a4fa53eaa3bf35ef45f";
+
+  appPath = "/Applications/oMLX.app";
+in
+lib.mkIf (profileName == "power") {
+  system.activationScripts.postActivation.text = lib.mkAfter ''
+    echo "Checking oMLX (${omlxVersion})..."
+
+    OMLX_INSTALLED=""
+    if [ -d "${appPath}" ]; then
+      OMLX_INSTALLED=$(/usr/bin/defaults read "${appPath}/Contents/Info" CFBundleShortVersionString 2>/dev/null || echo "")
+    fi
+
+    if [ "$OMLX_INSTALLED" = "${omlxVersion}" ]; then
+      echo "✓ oMLX ${omlxVersion} already installed"
+    else
+      OMLX_TMP=$(/usr/bin/mktemp -d)
+      OMLX_DMG="$OMLX_TMP/omlx.dmg"
+
+      echo "  Downloading oMLX ${omlxVersion} (~788MB)..."
+      # Every failure below is soft: an optional app must never take down a
+      # rebuild, and activation runs under `set -e`.
+      if ${pkgs.curl}/bin/curl -fsSL --max-time 1800 -o "$OMLX_DMG" "${omlxUrl}"; then
+        ACTUAL=$(${pkgs.coreutils}/bin/sha256sum "$OMLX_DMG" | ${pkgs.coreutils}/bin/cut -d' ' -f1)
+
+        if [ "$ACTUAL" != "${omlxSha256}" ]; then
+          echo "⚠ oMLX checksum mismatch — refusing to install"
+          echo "   expected ${omlxSha256}"
+          echo "   actual   $ACTUAL"
+        # Defence in depth: the checksum proves it is the file we pinned, and
+        # spctl proves Apple still vouches for its signature (a notarisation
+        # can be revoked after the fact).
+        elif ! /usr/sbin/spctl -a -t install "$OMLX_DMG" >/dev/null 2>&1; then
+          echo "⚠ oMLX DMG failed Gatekeeper verification — refusing to install"
+        else
+          OMLX_MNT="$OMLX_TMP/mnt"
+          /bin/mkdir -p "$OMLX_MNT"
+          if /usr/bin/hdiutil attach -nobrowse -readonly -mountpoint "$OMLX_MNT" "$OMLX_DMG" >/dev/null 2>&1; then
+            /bin/rm -rf "${appPath}"
+            if /bin/cp -R "$OMLX_MNT/oMLX.app" /Applications/; then
+              echo "✓ oMLX ${omlxVersion} installed to ${appPath}"
+            else
+              echo "⚠ oMLX copy failed — the app was left as-is"
+            fi
+            /usr/bin/hdiutil detach "$OMLX_MNT" >/dev/null 2>&1 || true
+          else
+            echo "⚠ Could not mount the oMLX DMG — skipping"
+          fi
+        fi
+      else
+        echo "⚠ oMLX download failed — skipping (the installed app is untouched)"
+      fi
+
+      /bin/rm -rf "$OMLX_TMP"
+    fi
+  '';
+}

--- a/flake.nix
+++ b/flake.nix
@@ -254,6 +254,11 @@
           # rsync Backup to NAS (Power profile only)
           # Automated backup of configured folders to TerraMaster NAS
           ./darwin/rsync-backup.nix
+
+          # oMLX menubar inference server (Power profile only)
+          # Installed from its notarized DMG - no cask exists, and its Homebrew
+          # formula sits in an untrusted tap whose trust state is undeclarable
+          ./darwin/omlx.nix
         ];
       };
 

--- a/scripts/disk-cleanup.sh
+++ b/scripts/disk-cleanup.sh
@@ -119,6 +119,13 @@ analyze_caches() {
     total_kb=$((total_kb + nodegyp_kb))
     print_status "info" "node-gyp cache: ${nodegyp_size}"
 
+    # Local model stores (llama.cpp GGUF + oMLX MLX), shared root from
+    # LLAMA_CACHE / OMLX_MODEL_DIR. Reported, never auto-pruned by size alone —
+    # these are deliberate downloads, not caches.
+    local models_root="${LOCAL_MODEL_ROOT:-$HOME/models}"
+    local local_models_size=$(get_size "${models_root}")
+    [[ "${local_models_size}" != "0B" ]] && print_status "info" "Local model store (${models_root}): ${local_models_size}"
+
     # Huggingface cache
     local hf_size=$(get_size ~/.cache/huggingface)
     local hf_kb=$(get_size_bytes ~/.cache/huggingface)
@@ -269,6 +276,40 @@ cleanup_huggingface() {
     fi
 }
 
+cleanup_local_models() {
+    # Prunes GGUF/MLX weights not read for LOCAL_MODEL_RETENTION_DAYS.
+    # Unlike the HF blob cache these are chosen downloads, so the window is
+    # generous and the default is report-only: pass --prune-models to delete.
+    print_header "Local Model Store"
+    local models_root="${LOCAL_MODEL_ROOT:-$HOME/models}"
+
+    if [[ ! -d "${models_root}" ]]; then
+        print_status "skip" "No local model store at ${models_root}"
+        return 0
+    fi
+
+    local retention="${LOCAL_MODEL_RETENTION_DAYS:-120}"
+    local before
+    before=$(get_size "${models_root}")
+
+    # GGUF are single files; MLX models are directories of safetensors, so the
+    # two are counted separately rather than with one find expression.
+    local stale_gguf
+    stale_gguf=$(find "${models_root}" -type f -name '*.gguf' -mtime "+${retention}" 2>/dev/null | wc -l | tr -d ' ')
+    local stale_mlx
+    stale_mlx=$(find "${models_root}" -mindepth 2 -maxdepth 3 -type d -mtime "+${retention}" 2>/dev/null | wc -l | tr -d ' ')
+
+    if [[ "${PRUNE_MODELS:-false}" == "true" ]]; then
+        find "${models_root}" -type f -name '*.gguf' -mtime "+${retention}" -delete 2>/dev/null || true
+        find "${models_root}" -mindepth 2 -maxdepth 3 -type d -mtime "+${retention}" -exec rm -rf {} + 2>/dev/null || true
+        print_status "cleaned" "Local models: ${stale_gguf} GGUF + ${stale_mlx} MLX pruned (was: ${before}, now: $(get_size "${models_root}"))"
+    elif [[ "${stale_gguf}" == "0" && "${stale_mlx}" == "0" ]]; then
+        print_status "info" "Local models: nothing unused for ${retention}d (${before})"
+    else
+        print_status "warn" "Local models: ${stale_gguf} GGUF + ${stale_mlx} MLX unused >${retention}d (${before}) — re-run with --prune-models to remove"
+    fi
+}
+
 cleanup_browsers() {
     # Cleans browser cache subdirs (Cache/, Code Cache/, GPUCache/) but never
     # touches profile data, bookmarks, cookies, or sessions.
@@ -403,6 +444,9 @@ main() {
 
     # Check for --dry-run or --analyze flag
     local dry_run=false
+    for arg in "$@"; do
+        [[ "${arg}" == "--prune-models" ]] && export PRUNE_MODELS=true
+    done
     if [[ "${1:-}" == "--dry-run" ]] || [[ "${1:-}" == "--analyze" ]] || [[ "${1:-}" == "-n" ]]; then
         dry_run=true
         echo ""
@@ -424,6 +468,7 @@ main() {
         cleanup_pip
         cleanup_nodegyp
         cleanup_huggingface
+        cleanup_local_models
         cleanup_browsers
         cleanup_containers
 

--- a/tests/darwin_system_packages.bats
+++ b/tests/darwin_system_packages.bats
@@ -49,6 +49,33 @@ common_package_lines() {
     [ "$status" -eq 1 ]
 }
 
+@test "local model stores share one root and are Power-gated" {
+    # llama.cpp (GGUF) and oMLX (MLX safetensors) hold different artefacts, so a
+    # shared root saves no disk - it exists so one retention rule and one digest
+    # line can cover all local model storage. Ollama cannot join: its models are
+    # content-addressed blobs in ~/.ollama/models, not a plain directory.
+    run rg -n 'LLAMA_CACHE' "$DARWIN_CONFIG"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'OMLX_MODEL_DIR' "$DARWIN_CONFIG"
+    [ "$status" -eq 0 ]
+
+    # Both must sit under the same parent so disk-cleanup can sweep one path
+    run rg -n 'localModelRoot' "$DARWIN_CONFIG"
+    [ "$status" -eq 0 ]
+}
+
+@test "disk-cleanup prunes the local model root" {
+    cleanup="${BATS_TEST_DIRNAME}/../scripts/disk-cleanup.sh"
+
+    run rg -n 'cleanup_local_models' "$cleanup"
+    [ "$status" -eq 0 ]
+
+    # Reported in the analyze pass too, or it stays invisible until it is huge
+    run rg -n 'local_models_size|Local model' "$cleanup"
+    [ "$status" -eq 0 ]
+}
+
 @test "1Password CLI ships via Homebrew on the Power profile only" {
     # Homebrew, not Nix: FX verified the brew formula works with the desktop
     # app's biometric integration, and it is 1Password's own documented path.

--- a/tests/package_manager_boundaries.bats
+++ b/tests/package_manager_boundaries.bats
@@ -27,6 +27,29 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "oMLX is installed from the notarized DMG, never Homebrew" {
+    OMLX_MODULE="${BATS_TEST_DIRNAME}/../darwin/omlx.nix"
+
+    [ -f "$OMLX_MODULE" ]
+
+    # The Homebrew formula lives in an untrusted third-party tap whose trust
+    # state (~/.homebrew/trust.json) cannot be declared, so a fresh machine
+    # would fail at `brew bundle`. The notarized DMG carries an Apple-verified
+    # Developer ID instead, and its checksum is pinned here.
+    run rg -n '"omlx"' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 1 ]
+
+    run rg -n 'jundot' "$HOMEBREW_CONFIG"
+    [ "$status" -eq 1 ]
+
+    # The download must be pinned by checksum and verified before install
+    run rg -n 'omlxSha256' "$OMLX_MODULE"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'spctl' "$OMLX_MODULE"
+    [ "$status" -eq 0 ]
+}
+
 @test "llama.cpp is owned only by Homebrew" {
     # nixpkgs also ships llama-cpp; declaring both would put two `llama-server`
     # binaries on PATH. Homebrew wins here because it tracks the project far


### PR DESCRIPTION
Two commits.

## 1. oMLX via notarized DMG, not Homebrew
No cask exists, and the formula sits in an **untrusted third-party tap**. Homebrew refuses untrusted formulae, and trust lives in `~/.homebrew/trust.json` — machine-local and undeclarable — so a fresh install would fail at `brew bundle`. The formula also built a 1.6GB Python venv from dozens of **unpinned** PyPI dependencies.

| | Formula | DMG |
|---|---|---|
| Identity | untrusted tap | **Apple-notarized Developer ID** (Heejun Kim, PSK5Q5T46L) |
| Install risk | unpinned PyPI tree | self-contained signed bundle |
| Reproducible | ✗ trust is machine-local | ✓ pinned URL + SHA-256 |

Two independent gates before install: the **checksum** proves it is the declared file; **spctl** proves Apple still vouches for the signature (notarisation can be revoked after the fact). Idempotent on `CFBundleShortVersionString`; all failure paths soft.

## 2. One root for local model stores
`LLAMA_CACHE=~/models/gguf`, `OMLX_MODEL_DIR=~/models/mlx` (Power only).

**This saves no disk** — GGUF and MLX safetensors are disjoint artefacts, so the same model in both is two full copies. It exists so one retention rule and one digest line can cover all local model storage. Left at their defaults these grow unbounded and invisibly, exactly like the 40GB HF cache and 44GB Ollama store found earlier this week.

**Ollama deliberately excluded.** Worth recording: it now serves **MLX**, not GGUF — all four local models use `application/vnd.ollama.image.tensor` layers. But it keeps content-addressed blobs plus manifests that no other runtime can read, so it cannot share a directory. `ollama-lru` prunes it.

`disk-cleanup.sh` reports the store and prunes weights unread for 120 days — **report-only unless `--prune-models`**. Unlike the HF blob cache these are deliberate multi-GB downloads; silently deleting one would be hostile. Both paths verified against a fixture.

Gates: `make test` 320/320 zero failures; `make nix-eval` clean on all 3 profiles; oMLX activation verified present on Power and absent on Standard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)