### PR TITLE
feat(models): dense-27b coding variant and declarative omlx sampling

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ nix-install/
 | **Commits** | 935 (+418 since v1.0.0) |
 | **Development** | ~20 active days (v1.0.0) + 2 days (Epic-08 sprint), ~96 hours through Epic-08; Epic-09/Epic-10 not yet estimated |
 | **Code** | 21K lines (Nix + Shell + Python, excluding the generated `bootstrap-dist.sh`) |
-| **Tests** | 1,473 test cases (48 BATS files, 325 in the active gate) |
+| **Tests** | 1,474 test cases (48 BATS files, 326 in the active gate) |
 | **Documentation** | 43K lines across 136 markdown files |
 | **GitHub Issues** | Epic-08 #236–#258 (23 stories) + fixes #269–#285 · Epic-09 #302–#303 · Epic-10 #388–#400 (13 stories) |
 | **Packages** | 31 casks (16 on AI-Assistant, 31 on Power), 12 brews, 6 MAS (5 on non-Power; Xcode is Power-only), 50+ Nix |

--- a/config/ollama/qwen3.6-dense-coding.Modelfile
+++ b/config/ollama/qwen3.6-dense-coding.Modelfile
@@ -1,0 +1,21 @@
+# ABOUTME: Derived Ollama model pinning Qwen3.6's recommended sampling parameters for agentic coding
+# ABOUTME: Dense-27B MLX sibling of qwen3.6-coding.Modelfile — same parameters, different base
+#
+# One-line swap of qwen3.6-coding.Modelfile: FROM the dense 27B MLX base
+# instead of the 35B-A3B MoE coding tune, for comparing dense vs MoE codegen
+# on Apple Silicon. Parameters are identical — see qwen3.6-coding.Modelfile
+# for the rationale behind each value (notably repeat_penalty 1.0 vs Ollama's
+# code-hostile 1.1 default).
+#
+# Build once after `ollama pull qwen3.6:27b-mlx`:
+#   ollama create qwen3.6-coding:dense -f config/ollama/qwen3.6-dense-coding.Modelfile
+
+FROM qwen3.6:27b-mlx
+
+PARAMETER num_ctx 48000
+PARAMETER temperature 0.6
+PARAMETER top_p 0.95
+PARAMETER top_k 20
+PARAMETER min_p 0.0
+PARAMETER repeat_penalty 1.0
+PARAMETER presence_penalty 0.0

--- a/darwin/omlx.nix
+++ b/darwin/omlx.nix
@@ -97,17 +97,38 @@ lib.mkIf (profileName == "power") {
     OMLX_TARGET_DIR="${homeDir}/models/mlx"
     /bin/mkdir -p "$OMLX_TARGET_DIR"
     /usr/sbin/chown ${userConfig.username}:staff "${homeDir}/models" "$OMLX_TARGET_DIR"
+    # Also converge the server-wide sampling defaults onto Qwen3.6's
+    # recommended profile — the same values config/ollama/qwen3.6-*.Modelfile
+    # pins for Ollama. OpenCode's omlx provider sends no per-request sampling,
+    # so these defaults are what oc-omlx sessions actually get; the app ships
+    # temperature 1.0, which is hostile to codegen. Global for every model
+    # oMLX serves (the catalogue is Qwen-dominated; clients can still
+    # override per request). The jq -e gate leaves an already-converged file
+    # untouched — the app rewrites settings.json on quit, so needless churn
+    # would race it.
     if [ -f "$OMLX_SETTINGS" ]; then
-      OMLX_CURRENT=$(${pkgs.jq}/bin/jq -r '.model.model_dir // ""' "$OMLX_SETTINGS" 2>/dev/null || echo "")
-      if [ "$OMLX_CURRENT" != "$OMLX_TARGET_DIR" ]; then
+      if ! ${pkgs.jq}/bin/jq -e --arg dir "$OMLX_TARGET_DIR" '
+             .model.model_dir == $dir
+             and .sampling.temperature == 0.6
+             and .sampling.top_k == 20
+             and .sampling.top_p == 0.95
+             and .sampling.repetition_penalty == 1.0
+             and .sampling.max_context_window == 48000
+           ' "$OMLX_SETTINGS" >/dev/null 2>&1; then
         OMLX_SETTINGS_TMP=$(/usr/bin/mktemp)
-        if ${pkgs.jq}/bin/jq --arg dir "$OMLX_TARGET_DIR" \
-             '.model.model_dir = $dir | .model.model_dirs = [$dir]' \
-             "$OMLX_SETTINGS" > "$OMLX_SETTINGS_TMP" 2>/dev/null; then
+        if ${pkgs.jq}/bin/jq --arg dir "$OMLX_TARGET_DIR" '
+             .model.model_dir = $dir
+             | .model.model_dirs = [$dir]
+             | .sampling.temperature = 0.6
+             | .sampling.top_k = 20
+             | .sampling.top_p = 0.95
+             | .sampling.repetition_penalty = 1.0
+             | .sampling.max_context_window = 48000
+           ' "$OMLX_SETTINGS" > "$OMLX_SETTINGS_TMP" 2>/dev/null; then
           # cat-over, not mv: preserves the file's owner and 0600 mode
           /bin/cat "$OMLX_SETTINGS_TMP" > "$OMLX_SETTINGS"
-          echo "✓ oMLX model_dir repointed at $OMLX_TARGET_DIR (was: ''${OMLX_CURRENT:-unset})"
-          echo "  Quit oMLX, then move existing weights: mv ~/.omlx/models/* $OMLX_TARGET_DIR/"
+          echo "✓ oMLX settings converged: model_dir $OMLX_TARGET_DIR + Qwen sampling profile"
+          echo "  Restart oMLX to pick them up (quit it first if running)"
         else
           echo "⚠ Could not patch oMLX settings.json — leaving it as-is"
         fi

--- a/tests/package_manager_boundaries.bats
+++ b/tests/package_manager_boundaries.bats
@@ -63,6 +63,23 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "oMLX sampling profile matches the Qwen coding Modelfiles" {
+    OMLX_MODULE="${BATS_TEST_DIRNAME}/../darwin/omlx.nix"
+
+    # oMLX's server-wide sampling defaults must mirror the parameters pinned
+    # in config/ollama/qwen3.6-*.Modelfile — OpenCode's omlx provider sends no
+    # per-request sampling, so these defaults are what oc-omlx actually gets.
+    # Notably temperature: the app ships 1.0, hostile to codegen.
+    run rg -n 'sampling\.temperature = 0\.6' "$OMLX_MODULE"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'sampling\.top_k = 20' "$OMLX_MODULE"
+    [ "$status" -eq 0 ]
+
+    run rg -n 'sampling\.max_context_window = 48000' "$OMLX_MODULE"
+    [ "$status" -eq 0 ]
+}
+
 @test "llama.cpp is owned only by Homebrew" {
     # nixpkgs also ships llama-cpp; declaring both would put two `llama-server`
     # binaries on PATH. Homebrew wins here because it tracks the project far


### PR DESCRIPTION
## Summary

- **`config/ollama/qwen3.6-dense-coding.Modelfile`** — builds `qwen3.6-coding:dense` from the dense `qwen3.6:27b-mlx` base with the exact sampling profile of `qwen3.6-coding:opencode` (MoE), enabling a clean dense-vs-MoE codegen A/B.
- **`darwin/omlx.nix`** — activation converges oMLX's server-wide `sampling` block onto the same Qwen profile alongside the existing `model_dir` patch. OpenCode's omlx provider sends no per-request sampling, so these server defaults are what `oc-omlx` sessions actually use — the app ships temperature 1.0, hostile to codegen. A `jq -e` gate makes converged files a no-op (verified live: the already-aligned settings on the M3 Max skip the write).

## Test plan
- New bats test pins the three load-bearing sampling values in the module (README 1,473 → 1,474, gate 325 → 326, integrity gate green)
- `nixfmt` clean, Power profile `nix eval` clean
- Verified live: `ollama show qwen3.6-coding:dense` reports all 7 parameters; oMLX serving with the aligned profile after relaunch

🤖 Generated with [Claude Code](https://claude.com/claude-code)